### PR TITLE
Added full decompilation of keylab_mk3

### DIFF
--- a/KeyLab_mk3/__init__.py
+++ b/KeyLab_mk3/__init__.py
@@ -1,0 +1,66 @@
+# Decompiled with PyLingual (https://pylingual.io)
+# Internal filename: ..\..\..\output\Live\win_64_static\Release\python-bundle\MIDI Remote Scripts\KeyLab_mk3\__init__.py
+# Bytecode version: 3.11a7e (3495)
+# Source timestamp: 2024-09-26 15:27:47 UTC (1727364467)
+
+from ableton.v3.control_surface import ControlSurface, \
+    ControlSurfaceSpecification, create_skin
+from ableton.v3.control_surface.capabilities import CONTROLLER_ID_KEY, NOTES_CC, \
+    PORTS_KEY, SCRIPT, controller_id, inport, outport
+
+try:
+    from ableton.v3.control_surface.capabilities import AUTO_LOAD_KEY
+except ImportError:
+    from ableton.v2.control_surface.capabilities import AUTO_LOAD_KEY
+from .active_parameter import ActiveParameterComponent
+from .colors import Rgb, Skin
+from .display import display_specification
+from .elements import Elements
+from .mappings import create_mappings
+from .midi import CONNECTION_MESSAGE, DISCONNECTION_MESSAGE
+from .mixer import MixerComponent
+from .mode_buttons import ModeButtonsComponent
+from .scene_launch import SceneLaunchComponent
+
+
+def get_capabilities():
+    return {CONTROLLER_ID_KEY: controller_id(vendor_id=7285,
+                                             product_ids=[590, 654, 718],
+                                             model_name=['KeyLab 49 mk3',
+                                                         'KeyLab 61 mk3',
+                                                         'KeyLab 88 mk3']),
+            PORTS_KEY: [inport(props=[NOTES_CC]),
+                        inport(props=[NOTES_CC, SCRIPT]),
+                        outport(props=[NOTES_CC]),
+                        outport(props=[NOTES_CC, SCRIPT])], AUTO_LOAD_KEY: True}
+
+
+def create_instance(c_instance):
+    return KeyLab_mk3(specification=Specification, c_instance=c_instance)
+
+
+class Specification(ControlSurfaceSpecification):
+    elements_type = Elements
+    control_surface_skin = create_skin(skin=Skin, colors=Rgb)
+    num_tracks = 4
+    num_scenes = 3
+    link_session_ring_to_track_selection = True
+    link_session_ring_to_scene_selection = True
+    include_auto_arming = True
+    identity_response_id_bytes = (0, 32, 107, 2, 0, 10)
+    create_mappings_function = create_mappings
+    hello_messages = (CONNECTION_MESSAGE,)
+    goodbye_messages = (DISCONNECTION_MESSAGE,)
+    parameter_bank_size = 16
+    component_map = {'Active_Parameter': ActiveParameterComponent,
+                     'Mixer': MixerComponent,
+                     'Mode_Buttons': ModeButtonsComponent,
+                     'Scene_Launch': SceneLaunchComponent}
+    display_specification = display_specification
+
+
+class KeyLab_mk3(ControlSurface):
+
+    def __init__(self, *a, **k):
+        super().__init__(*a, **k)
+        self.set_can_auto_arm(True)

--- a/KeyLab_mk3/active_parameter.py
+++ b/KeyLab_mk3/active_parameter.py
@@ -1,0 +1,35 @@
+# Decompiled with PyLingual (https://pylingual.io)
+# Internal filename: ..\..\..\output\Live\win_64_static\Release\python-bundle\MIDI Remote Scripts\KeyLab_mk3\active_parameter.py
+# Bytecode version: 3.11a7e (3495)
+# Source timestamp: 2024-09-26 15:27:47 UTC (1727364467)
+
+from ableton.v3.base import find_if, listenable_property
+from ableton.v3.control_surface.components import \
+    ActiveParameterComponent as ActiveParameterComponentBase
+from ableton.v3.live import liveobj_valid
+
+
+class ActiveParameterComponent(ActiveParameterComponentBase):
+    pass
+
+    def __init__(self, *a, **k):
+        super().__init__(*a, **k)
+        self._is_fader_map = {}
+
+    def set_touch_controls(self, controls):
+        self.touch_controls.set_control_element(controls)
+        if controls:
+            self._is_fader_map = {c: int(c.name.split('_')[-1]) > 8 for c in
+                                  controls}
+
+    @listenable_property
+    def is_fader(self):
+        return self._is_fader_map.get(
+            find_if(lambda elem: liveobj_valid(elem.controlled_parameter),
+                    (elem for elem in
+                     reversed(list(self._pressed_touch_elements.values())))),
+            False)
+
+    def notify_parameter(self):
+        super().notify_parameter()
+        self.notify_is_fader()

--- a/KeyLab_mk3/colors.py
+++ b/KeyLab_mk3/colors.py
@@ -1,0 +1,74 @@
+# Decompiled with PyLingual (https://pylingual.io)
+# Internal filename: ..\..\..\output\Live\win_64_static\Release\python-bundle\MIDI Remote Scripts\KeyLab_mk3\colors.py
+# Bytecode version: 3.11a7e (3495)
+# Source timestamp: 2024-09-26 15:27:47 UTC (1727364467)
+
+from ableton.v3.control_surface import BasicColors
+from ableton.v3.control_surface.elements import FallbackColor, create_rgb_color
+from ableton.v3.live import liveobj_color_to_midi_rgb_values
+
+
+def create_color(r, g, b):
+    return create_rgb_color((r, g, b, 0))
+
+
+class Rgb:
+    OFF = FallbackColor(create_color(0, 0, 0), BasicColors.OFF)
+    WHITE_HALF = create_color(32, 32, 32)
+    WHITE = FallbackColor(create_color(127, 127, 127), BasicColors.ON)
+    RED = create_color(127, 0, 0)
+    RED_HALF = create_color(32, 0, 0)
+    RED_LOW = create_color(16, 0, 0)
+    GREEN = create_color(0, 127, 0)
+    GREEN_HALF = create_color(0, 32, 0)
+    YELLOW = create_color(127, 72, 0)
+    YELLOW_HALF = create_color(32, 24, 0)
+
+
+class Skin:
+    class DefaultButton:
+        On = Rgb.WHITE
+        Off = Rgb.OFF
+        Disabled = Rgb.OFF
+
+    class Transport:
+        PlayOn = Rgb.GREEN
+        PlayOff = Rgb.GREEN_HALF
+        StopOn = Rgb.WHITE
+        StopOff = Rgb.WHITE_HALF
+        LoopOn = Rgb.YELLOW
+        LoopOff = Rgb.YELLOW_HALF
+        MetronomeOn = Rgb.WHITE
+        MetronomeOff = Rgb.WHITE_HALF
+        TapTempoPressed = Rgb.WHITE
+        TapTempo = Rgb.WHITE_HALF
+        SeekPressed = Rgb.WHITE
+        Seek = Rgb.WHITE_HALF
+        CanCaptureMidi = Rgb.WHITE
+
+    class Recording:
+        ArrangementRecordOn = Rgb.RED
+        ArrangementRecordOff = Rgb.RED_HALF
+        SessionRecordOn = Rgb.RED
+        SessionRecordOff = Rgb.RED_HALF
+
+    class UndoRedo:
+        UndoPressed = Rgb.WHITE
+        Undo = Rgb.WHITE_HALF
+        RedoPressed = Rgb.WHITE
+        Redo = Rgb.WHITE_HALF
+
+    class ClipActions:
+        Quantize = Rgb.WHITE_HALF
+        QuantizePressed = Rgb.WHITE
+
+    class Session:
+        Slot = Rgb.OFF
+        SlotRecordButton = Rgb.RED_LOW
+        NoSlot = Rgb.OFF
+        ClipStopped = lambda x: create_color(
+            *liveobj_color_to_midi_rgb_values(x))
+        ClipTriggeredPlay = Rgb.GREEN_HALF
+        ClipPlaying = Rgb.GREEN
+        ClipTriggeredRecord = Rgb.RED_HALF
+        ClipRecording = Rgb.RED

--- a/KeyLab_mk3/display.py
+++ b/KeyLab_mk3/display.py
@@ -1,0 +1,243 @@
+# Decompiled with PyLingual (https://pylingual.io)
+# Internal filename: ..\..\..\output\Live\win_64_static\Release\python-bundle\MIDI Remote Scripts\KeyLab_mk3\display.py
+# Bytecode version: 3.11a7e (3495)
+# Source timestamp: 2024-09-26 15:27:47 UTC (1727364467)
+
+from dataclasses import dataclass
+from enum import IntEnum
+from functools import partial
+from typing import Optional, Tuple
+
+from ableton.v3.control_surface.display import DefaultNotifications, \
+    DisplaySpecification, Text, view
+from ableton.v3.live import display_name, is_track_armed, \
+    liveobj_color_to_midi_rgb_values, liveobj_name, \
+    parameter_value_to_midi_value, scene_index, simple_track_name, song
+
+Line1Text = partial(Text, max_width=17, justification=Text.Justification.NONE)
+Line2Text = partial(Text, max_width=30, justification=Text.Justification.NONE)
+PopupLine2Text = partial(Text, max_width=21,
+                         justification=Text.Justification.NONE)
+BUTTON_TYPES = {'toggle': (2, 3), 'tab': (4, 6), 'icon': (10, 11)}
+
+
+class ScreenId(IntEnum):
+    TWO_LINE = 13
+    TWO_LINE_POPUP = 24
+    THREE_LINE_POPUP = 25
+    ENCODER_PARAMETER = 28
+    FADER_PARAMETER = 29
+    ICONIFIED_TWO_LINE_POPUP = 31
+
+
+class Icon(IntEnum):
+    NONE = 0
+    UP = 1
+    DOWN = 2
+    AUDIO_ARM = 5
+    MIDI_ARM = 6
+    PLAY = 12
+    SOLO = 13
+    STOP = 14
+    ABLETON = 60
+
+
+class Color:
+    BLACK = (0, 0, 0)
+    GREY = (66, 66, 66)
+    WHITE = (127, 127, 127)
+    RED = (120, 28, 19)
+    GREEN = (0, 127, 0)
+    BLUE = (0, 108, 122)
+    YELLOW = (127, 88, 0)
+
+
+@dataclass
+class ParameterContent:
+    name: str
+    value_as_str: str
+    value: int
+    screen_id: ScreenId
+
+
+@dataclass
+class ButtonContent:
+    text: Optional[str] = None
+    icon: Optional[Icon] = Icon.NONE
+    on_color: Optional[Color] = Color.WHITE
+    off_color: Optional[Color] = Color.WHITE
+    is_on: Optional[bool] = False
+    button_type: Optional[tuple] = BUTTON_TYPES['icon']
+
+    @property
+    def color(self):
+        return self.on_color if self.is_on else self.off_color
+
+
+@dataclass
+class Content:
+    primary_lines: Optional[Tuple[str, str]] = None
+    primary_color: Optional[Color] = Color.WHITE
+    popup_lines: Optional[Tuple[str, str, str]] = None
+    popup_colors: Optional[Tuple[Color, Color, Color]] = (
+        Color.WHITE, Color.WHITE, Color.WHITE)
+    popup_icon: Optional[Icon] = Icon.NONE
+    parameter: Optional[ParameterContent] = None
+    context_buttons: Optional[Tuple[
+        ButtonContent, ButtonContent, ButtonContent, ButtonContent, ButtonContent, ButtonContent, ButtonContent, ButtonContent]] = None
+
+
+class Notifications(DefaultNotifications):
+    identify = lambda: Content(popup_lines=('Ableton Live', 'Connected'),
+                               popup_icon=Icon.ABLETON)
+    controlled_range = 'mixer'
+
+    class Transport(DefaultNotifications.Transport):
+        tap_tempo = lambda tempo: Content(
+            popup_lines=('Tap Tempo', '{:0.2f} BPM'.format(tempo)),
+            popup_colors=(Color.WHITE, Color.BLUE))
+
+    class Device(DefaultNotifications.Device):
+        select = 'device'
+
+
+def render_notification(state, notification):
+    if notification == 'mixer':
+        return create_mixer_popup_screen(state)
+    if notification == 'device':
+        return create_device_popup_screen(state)
+    return notification
+
+
+def create_mixer_popup_screen(state):
+    if state.continuous_control_modes.selected_mode == 'mixer':
+        return Content(popup_lines=(
+            'Mixer Control', state.mixer_session_ring.controlled_range,
+            'HOLD TO OFFSET'),
+            popup_colors=(Color.WHITE, Color.BLUE, Color.GREY))
+    return None
+
+
+def create_device_popup_screen(state):
+    if state.continuous_control_modes.selected_mode == 'device':
+        return Content(popup_lines=(
+            'Device Control', liveobj_name(state.device.device) or 'No Device',
+            'HOLD TO SELECT DEVICES'),
+            popup_colors=(Color.WHITE, Color.BLUE, Color.GREY))
+    return None
+
+
+def create_mixer_button_content(state):
+    track = state.target_track.target_track
+    return (ButtonContent(text=simple_track_name(track), on_color=Color.YELLOW,
+                          is_on=track != song().master_track and (
+                              not track.mute),
+                          button_type=BUTTON_TYPES['toggle']),
+            ButtonContent(icon=Icon.SOLO, on_color=Color.BLUE,
+                          is_on=track != song().master_track and (track.solo)),
+            ButtonContent(
+                icon=Icon.MIDI_ARM if track.has_midi_input else Icon.AUDIO_ARM,
+                on_color=Color.RED, is_on=is_track_armed(track)),
+            ButtonContent(icon=Icon.STOP, on_color=Color.RED,
+                          is_on=True) if state.scene_launch.launch_button.is_held else ButtonContent(
+                icon=Icon.PLAY, on_color=Color.GREEN,
+                is_on=song().view.selected_scene.is_triggered))
+
+
+def create_mode_button_content(state, mode_name):
+    return ButtonContent(text=mode_name.upper(),
+                         is_on=state.continuous_control_modes.selected_mode == mode_name,
+                         button_type=BUTTON_TYPES['tab'])
+
+
+def create_navigation_button_content():
+    index = scene_index()
+    return (ButtonContent(icon=Icon.UP,
+                          off_color=Color.WHITE if index > 0 else Color.GREY),
+            ButtonContent(icon=Icon.DOWN, off_color=Color.WHITE if index < len(
+                song().scenes) - 1 else Color.GREY))
+
+
+def create_root_view() -> view.View[Optional[Content]]:
+    @view.View
+    def main_view(state) -> Optional[Content]:
+        if state.mode_buttons.device_button.is_held:
+            return create_device_popup_screen(state)
+        if state.mode_buttons.mixer_button.is_held:
+            return create_mixer_popup_screen(state)
+        return Content(primary_lines=(
+            liveobj_name(state.target_track.target_track),
+            display_name(song().view.selected_scene)),
+            primary_color=liveobj_color_to_midi_rgb_values(
+                state.target_track.target_track), context_buttons=(
+                *create_mixer_button_content(state),
+                create_mode_button_content(state, 'device'),
+                create_mode_button_content(state, 'mixer'),
+                *create_navigation_button_content()))
+
+    @view.View
+    def parameter_view(state) -> Optional[Content]:
+        active_parameter = state.active_parameter.parameter
+        if active_parameter:
+            return Content(
+                parameter=ParameterContent(name=display_name(active_parameter),
+                                           value_as_str=str(active_parameter),
+                                           value=parameter_value_to_midi_value(
+                                               active_parameter),
+                                           screen_id=ScreenId.FADER_PARAMETER if state.active_parameter.is_fader else ScreenId.ENCODER_PARAMETER))
+        return None
+
+    return view.CompoundView(view.DisconnectedView(),
+                             view.NotificationView(render_notification),
+                             parameter_view, main_view)
+
+
+def protocol(elements):
+    def display(content: Content):
+        if content:
+            display_primary_content(content.primary_lines,
+                                    content.primary_color)
+            display_context_button_content(content.context_buttons)
+            display_parameter_content(content.parameter)
+            display_popup_content(content.popup_lines, content.popup_colors,
+                                  content.popup_icon)
+
+    def display_primary_content(text, color):
+        if text:
+            with elements.display_full_screen_command.deferring_send():
+                elements.display_line_1.display_message(text[0])
+                elements.display_line_2.display_message(text[1])
+                elements.display_full_screen_command.send_value(color=color)
+
+    def display_context_button_content(content):
+        if content:
+            for i, button in enumerate(content):
+                if button.text or button.icon:
+                    getattr(elements,
+                            'display_button_command_{}'.format(i)).send_value(
+                        text=Text(button.text).as_ascii(),
+                        button_type=button.button_type[int(button.is_on)],
+                        color=button.color, icon=button.icon)
+
+    def display_parameter_content(parameter):
+        if parameter:
+            elements.display_parameter_command.send_value(
+                screen_id=parameter.screen_id,
+                name=Text(parameter.name).as_ascii(),
+                value_as_str=Text(parameter.value_as_str).as_ascii(),
+                value=parameter.value)
+
+    def display_popup_content(text, colors, icon):
+        if text:
+            elements.display_popup_command.send_value(
+                line_1=Text(text[0]).as_ascii(),
+                line_2=PopupLine2Text(text[1]).as_ascii(),
+                line_3=Text(text[2]).as_ascii() if len(text) == 3 else None,
+                colors=colors, icon=icon)
+
+    return display
+
+
+display_specification = DisplaySpecification(create_root_view=create_root_view,
+                                             protocol=protocol,
+                                             notifications=Notifications)

--- a/KeyLab_mk3/elements.py
+++ b/KeyLab_mk3/elements.py
@@ -1,0 +1,118 @@
+# Decompiled with PyLingual (https://pylingual.io)
+# Internal filename: ..\..\..\output\Live\win_64_static\Release\python-bundle\MIDI Remote Scripts\KeyLab_mk3\elements.py
+# Bytecode version: 3.11a7e (3495)
+# Source timestamp: 2024-09-26 15:27:47 UTC (1727364467)
+
+from functools import partial
+
+from ableton.v3.control_surface import MIDI_NOTE_TYPE, ElementsBase, MapMode, \
+    create_button, create_encoder, create_matrix_identifiers, \
+    create_sysex_sending_button
+from ableton.v3.control_surface.elements import CachingSendMessageGenerator, \
+    DisplayLineElement, TouchElement
+from . import midi
+from .display import Line1Text, Line2Text, ScreenId
+
+
+def create_rgb_button(identifier, name=None, **k):
+    return create_sysex_sending_button(identifier, name, midi.LED_HEADER + (
+    midi.BUTTON_ID_TO_SYSEX_ID[identifier],), is_rgb=True, **k)
+
+
+def create_rgb_pad(identifier, name, **k):
+    return create_sysex_sending_button(identifier, name, midi.LED_HEADER + (
+    midi.PAD_ID_TO_SYSEX_ID[identifier],), msg_type=MIDI_NOTE_TYPE, is_rgb=True,
+                                       **k)
+
+
+def create_continuous_control(identifier, name, **k):
+    return create_encoder(identifier, name,
+                          map_mode=MapMode.Absolute if identifier >= 105 else MapMode.LinearBinaryOffset,
+                          **k)
+
+
+class Elements(ElementsBase):
+    def __init__(self, *a, **k):
+        super().__init__(*a, **k)
+        self.add_modifier_button(45, 'Context_Button_0')
+        self.add_modifier_button(46, 'Context_Button_1')
+        self.add_button(20, 'Stop_Button')
+        self.add_button(21, 'Play_Button')
+        self.add_button(22, 'Record_Button')
+        self.add_button(23, 'Tap_Button')
+        self.add_button(24, 'Loop_Button')
+        self.add_button(25, 'Rewind_Button')
+        self.add_button(26, 'Fastforward_Button')
+        self.add_button(27, 'Metronome_Button')
+        self.add_button(40, 'Back_Button')
+        self.add_button(41, 'Save_Button')
+        self.add_button(42, 'Quantize_Button')
+        self.add_button(43, 'Undo_Button')
+        self.add_button(44, 'Redo_Button')
+        for i in range(2, 8):
+            self.add_button(45 + i, 'Context_Button_{}'.format(i))
+        self.add_matrix(create_matrix_identifiers(0, 12, width=4), 'Pads',
+                        element_factory=create_rgb_pad, channels=9)
+        self.add_encoder(104, 'Encoder_8', map_mode=MapMode.LinearBinaryOffset)
+        self.add_encoder(113, 'Fader_8')
+        self.add_encoder(116, 'Display_Encoder',
+                         map_mode=MapMode.LinearBinaryOffset)
+        self.add_modified_control(control=self.display_encoder,
+                                  modifier=self.context_button_0)
+        self.add_modified_control(control=self.display_encoder,
+                                  modifier=self.context_button_1)
+        self.add_matrix(
+            [[91, 92, 94, 95, 96, 97, 102, 103] + list(range(105, 113))],
+            'Continuous_Controls', element_factory=create_continuous_control)
+        self.add_submatrix(self.continuous_controls, 'Encoders', columns=(0, 8))
+        self.add_submatrix(self.continuous_controls, 'Faders', columns=(8, 16))
+        self.add_matrix([midi.ENCODER_TOUCH_IDS + midi.FADER_TOUCH_IDS],
+                        'Parameter_Touch_Elements',
+                        element_factory=self.create_touch_element)
+        self.add_sysex_element(midi.DISPLAY_HEADER,
+                               'Display_Full_Screen_Command',
+                               send_message_generator=CachingSendMessageGenerator(
+                                   midi.make_two_line_screen), optimized=True)
+        self.display_line_1 = DisplayLineElement(name='Display_Line_1',
+                                                 display_fn=lambda
+                                                     message: self.display_full_screen_command.send_value(
+                                                     line_1=message),
+                                                 default_formatting=Line1Text())
+        self.display_line_2 = DisplayLineElement(name='Display_Line_2',
+                                                 display_fn=lambda
+                                                     message: self.display_full_screen_command.send_value(
+                                                     line_2=message),
+                                                 default_formatting=Line2Text())
+        self.add_sysex_element(midi.DISPLAY_HEADER + (ScreenId.TWO_LINE_POPUP,),
+                               'Display_Popup_Command',
+                               send_message_generator=midi.make_popup_screen)
+        self.add_sysex_element(
+            midi.DISPLAY_HEADER + (ScreenId.ENCODER_PARAMETER,),
+            "Display_Parameter_Command",
+            send_message_generator=midi.make_parameter_screen, optimized=True, )
+        for i in range(8):
+            self.add_sysex_element(midi.DISPLAY_HEADER + (i + 1,),
+                'Display_Button_Command_{}'.format(i),
+                send_message_generator=partial(midi.make_button_segment, i + 1),
+                optimized=True, )
+
+    def add_button(self, identifier, name, **k):
+        self.add_element(name,
+                         create_rgb_button if identifier in midi.BUTTON_ID_TO_SYSEX_ID else create_button,
+                         identifier, **k)
+
+    def create_touch_element(self, identifier, **k):
+        # Determine the control type based on the identifier
+        if identifier == 38:
+            host_control = self.encoder_8
+        elif identifier == 37:
+            host_control = self.fader_8
+        elif identifier in midi.ENCODER_TOUCH_IDS:
+            host_control = self.continuous_controls_raw[
+                midi.ENCODER_TOUCH_IDS.index(identifier)]
+        else:
+            host_control = self.continuous_controls_raw[
+                midi.FADER_TOUCH_IDS.index(identifier) + 8]
+
+        # Return a TouchElement instance
+        return TouchElement(identifier, encoder=host_control, **k)

--- a/KeyLab_mk3/mappings.py
+++ b/KeyLab_mk3/mappings.py
@@ -1,0 +1,47 @@
+# Decompiled with PyLingual (https://pylingual.io)
+# Internal filename: ..\..\..\output\Live\win_64_static\Release\python-bundle\MIDI Remote Scripts\KeyLab_mk3\mappings.py
+# Bytecode version: 3.11a7e (3495)
+# Source timestamp: 2024-09-26 15:27:47 UTC (1727364467)
+
+from ableton.v3.control_surface.mode import ImmediateBehaviour
+
+
+def create_mappings(_):
+    mappings = {}
+    mappings['Transport'] = dict(play_button='play_button',
+                                 stop_button='stop_button',
+                                 metronome_button='metronome_button',
+                                 loop_button='loop_button',
+                                 tap_tempo_button='tap_button',
+                                 rewind_button='rewind_button',
+                                 fastforward_button='fastforward_button',
+                                 capture_midi_button='save_button')
+    mappings['View_Based_Recording'] = dict(record_button='record_button')
+    mappings['Undo_Redo'] = dict(undo_button='undo_button',
+                                 redo_button='redo_button')
+    mappings['Clip_Actions'] = dict(quantize_button='quantize_button')
+    mappings['View_Control'] = dict(prev_scene_button='context_button_2',
+                                    next_scene_button='context_button_3',
+                                    track_encoder='display_encoder')
+    mappings['Mixer'] = dict(target_track_mute_button='context_button_4',
+                             target_track_solo_button='context_button_5',
+                             target_track_arm_button='context_button_6',
+                             target_track_volume_control='fader_8',
+                             target_track_pan_control='encoder_8')
+    mappings['Session'] = dict(clip_launch_buttons='pads')
+    mappings['Scene_Launch'] = dict(launch_button='context_button_7')
+    mappings['Active_Parameter'] = dict(
+        touch_controls='parameter_touch_elements')
+    mappings['Mode_Buttons'] = dict(device_button='context_button_0',
+                                    mixer_button='context_button_1')
+    mappings['Continuous_Control_Modes'] = dict(
+        device_button='context_button_0', mixer_button='context_button_1',
+        device=dict(modes=[
+            dict(component='Device', parameter_controls='continuous_controls'),
+            dict(component='Device_Navigation',
+                 scroll_encoder='display_encoder_with_context_button_0')]),
+        mixer=dict(component='Mixer', volume_controls='faders',
+                   pan_controls='encoders',
+                   track_bank_encoder='display_encoder_with_context_button_1'),
+        default_behaviour=ImmediateBehaviour())
+    return mappings

--- a/KeyLab_mk3/midi.py
+++ b/KeyLab_mk3/midi.py
@@ -1,0 +1,62 @@
+from ableton.v3.control_surface.midi import SYSEX_END, SYSEX_START
+from .display import BUTTON_TYPES, Color, Icon, ScreenId
+
+# Define headers
+SYSEX_HEADER = (SYSEX_START, 0, 32, 107, 127, 66)
+LED_HEADER = SYSEX_HEADER + (4, 2, 3)
+DISPLAY_HEADER = SYSEX_HEADER + (0, 2, 4)
+
+# Connection messages
+make_connection_message = lambda parameter_byte: SYSEX_HEADER + (
+0, 2, 5, parameter_byte, SYSEX_END)
+
+CONNECTION_MESSAGE = make_connection_message(1)
+DISCONNECTION_MESSAGE = make_connection_message(0)
+
+# ID mappings
+BUTTON_ID_TO_SYSEX_ID = {20: 7, 21: 6, 22: 5, 23: 4, 24: 8, 25: 9, 26: 10,
+    27: 11, 41: 15, 42: 14, 43: 13, 44: 12}
+
+PAD_ID_TO_SYSEX_ID = {0: 82, 1: 83, 2: 84, 3: 85, 4: 86, 5: 87, 6: 88, 7: 89,
+    8: 90, 9: 91, 10: 92, 11: 93}
+
+# Touch IDs
+ENCODER_TOUCH_IDS = (8, 9, 10, 11, 12, 13, 14, 15, 38)
+FADER_TOUCH_IDS = (28, 29, 30, 31, 32, 34, 35, 36, 37)
+
+
+# Function definitions
+def make_parameter_screen(screen_id, name, value_as_str, value):
+    pass
+    return DISPLAY_HEADER + (screen_id,) + (0,) + value_as_str + (
+    0, 1) + name + (0, 2, value, 0) + (4,) + Color.BLUE + (0, SYSEX_END)
+
+
+def make_button_segment(button_index, text=None,
+    button_type=BUTTON_TYPES['icon'][0], color=Color.WHITE, icon=Icon.NONE):
+    pass
+    return DISPLAY_HEADER + (button_index,) + (0, button_type,) + (
+    0, 3, icon) + (0, 4) + color + (0, 5) + (text if text else (0,)) + (
+    0, SYSEX_END)
+
+
+def make_two_line_screen(line_1, line_2, color=Color.WHITE):
+    pass
+    return DISPLAY_HEADER + (ScreenId.TWO_LINE,) + make_line_bytes(line_1,
+                                                                   color) + make_line_bytes(
+        line_2, Color.WHITE, address=3) + (SYSEX_END,)
+
+
+def make_popup_screen(line_1, line_2, line_3=None,
+    colors=(Color.WHITE, Color.WHITE, Color.WHITE), icon=Icon.NONE):
+    pass
+    return DISPLAY_HEADER + (
+    ScreenId.THREE_LINE_POPUP if line_3 else ScreenId.ICONIFIED_TWO_LINE_POPUP if icon else ScreenId.TWO_LINE_POPUP,) + make_line_bytes(
+        line_1, colors[0]) + make_line_bytes(line_2, colors[1], address=3) + (
+        (make_line_bytes(line_3, colors[2], address=6)) if line_3 else ()) + (
+        (6, icon, 0,) if line_3 is None else ()) + (SYSEX_END,)
+
+
+def make_line_bytes(line, color, address=0):
+    pass
+    return (address,) + line + (0, address + 2) + color + (0,)

--- a/KeyLab_mk3/mixer.py
+++ b/KeyLab_mk3/mixer.py
@@ -1,0 +1,55 @@
+# Decompiled with PyLingual (https://pylingual.io)
+# Internal filename: ..\..\..\output\Live\win_64_static\Release\python-bundle\MIDI Remote Scripts\KeyLab_mk3\mixer.py
+# Bytecode version: 3.11a7e (3495)
+# Source timestamp: 2024-09-26 15:27:47 UTC (1727364467)
+
+from ableton.v3.base import find_if, listenable_property, nop
+from ableton.v3.control_surface.components import \
+    MixerComponent as MixerComponentBase
+from ableton.v3.control_surface.components import \
+    SessionNavigationComponent as SessionNavigationComponentBase
+from ableton.v3.control_surface.components import SessionRingComponent
+from ableton.v3.live import liveobj_valid, simple_track_name
+
+
+class SessionNavigationComponent(SessionNavigationComponentBase):
+    pass
+
+    def set_horizontal_page_encoder(self, encoder):
+        self._horizontal_paging.set_scroll_encoder(encoder)
+
+
+class MixerSessionRingComponent(SessionRingComponent):
+    pass
+
+    def __init__(self, *a, **k):
+        super().__init__(*a, name='Mixer_Session_Ring', num_tracks=8,
+                         set_session_highlight=nop, is_private=True, **k)
+
+    @listenable_property
+    def controlled_range(self):
+        tracks = self.tracks
+        last_track = find_if(liveobj_valid, reversed(tracks))
+        return 'Tracks {} to {}'.format(simple_track_name(tracks[0]),
+                                        simple_track_name(last_track))
+
+    def move(self, tracks, scenes):
+        super().move(tracks, scenes)
+        self.notify_controlled_range()
+        self.notify(self.notifications.controlled_range, '',
+                    self.controlled_range)
+
+
+class MixerComponent(MixerComponentBase):
+    pass
+
+    def __init__(self, *a, **k):
+        self._session_ring = MixerSessionRingComponent()
+        super().__init__(*a, session_ring=self._session_ring, **k)
+        self._session_navigation = SessionNavigationComponent(
+            session_ring=self._session_ring, snap_track_offset=True,
+            parent=self)
+        self.add_children(self._session_ring)
+
+    def set_track_bank_encoder(self, encoder):
+        self._session_navigation.set_horizontal_page_encoder(encoder)

--- a/KeyLab_mk3/mode_buttons.py
+++ b/KeyLab_mk3/mode_buttons.py
@@ -1,0 +1,17 @@
+# Decompiled with PyLingual (https://pylingual.io)
+# Internal filename: ..\..\..\output\Live\win_64_static\Release\python-bundle\MIDI Remote Scripts\KeyLab_mk3\mode_buttons.py
+# Bytecode version: 3.11a7e (3495)
+# Source timestamp: 2024-09-26 15:27:47 UTC (1727364467)
+
+from ableton.v3.control_surface import Component
+from ableton.v3.control_surface.controls import ButtonControl
+from ableton.v3.control_surface.display import Renderable
+
+
+class ModeButtonsComponent(Component, Renderable):
+    pass
+    device_button = ButtonControl()
+    mixer_button = ButtonControl()
+
+    def __init__(self, *a, **k):
+        super().__init__(*a, name='Mode_Buttons', **k)

--- a/KeyLab_mk3/scene_launch.py
+++ b/KeyLab_mk3/scene_launch.py
@@ -1,0 +1,24 @@
+# Decompiled with PyLingual (https://pylingual.io)
+# Internal filename: ..\..\..\output\Live\win_64_static\Release\python-bundle\MIDI Remote Scripts\KeyLab_mk3\scene_launch.py
+# Bytecode version: 3.11a7e (3495)
+# Source timestamp: 2024-09-26 15:27:47 UTC (1727364467)
+
+from ableton.v3.control_surface import Component
+from ableton.v3.control_surface.controls import ButtonControl
+from ableton.v3.control_surface.display import Renderable
+
+
+class SceneLaunchComponent(Component, Renderable):
+    pass
+    launch_button = ButtonControl()
+
+    def __init__(self, *a, **k):
+        super().__init__(*a, name='Scene_Launch', **k)
+
+    @launch_button.released_immediately
+    def launch_button(self, _):
+        self.song.view.selected_scene.fire()
+
+    @launch_button.pressed_delayed
+    def launch_button(self, _):
+        self.song.stop_all_clips()

--- a/MackieControl/ChannelStrip.py
+++ b/MackieControl/ChannelStrip.py
@@ -1,73 +1,76 @@
-# uncompyle6 version 3.9.1
-# Python bytecode version base 3.7.0 (3394)
-# Decompiled from: Python 3.12.2 (main, Feb  6 2024, 20:19:44) [Clang 15.0.0 (clang-1500.1.0.2.5)]
-# Embedded file name: output/Live/mac_universal_64_static/Release/python-bundle/MIDI Remote Scripts/MackieControl/ChannelStrip.py
-# Compiled at: 2024-03-09 01:30:22
-# Size of source mod 2**32: 23418 bytes
-from __future__ import absolute_import, print_function, unicode_literals
-from builtins import range
+# Embedded file name: /Users/versonator/Jenkins/live/output/Live/mac_64_static/Release/python-bundle/MIDI Remote Scripts/MackieControl/ChannelStrip.py
+# from __future__ import absolute_import, print_function, unicode_literals
 from itertools import chain
+
 from ableton.v2.base import liveobj_valid
+# from builtins import range
 from .MackieControlComponent import *
 
+
 class ChannelStrip(MackieControlComponent):
+    # """ Represets a Channel Strip of the Mackie Control, which consists out of the """
+
 
     def __init__(self, main_script, strip_index):
         MackieControlComponent.__init__(self, main_script)
-        self._ChannelStrip__channel_strip_controller = None
-        self._ChannelStrip__is_touched = False
-        self._ChannelStrip__strip_index = strip_index
-        self._ChannelStrip__stack_offset = 0
-        self._ChannelStrip__bank_and_channel_offset = 0
-        self._ChannelStrip__assigned_track = None
-        self._ChannelStrip__v_pot_parameter = None
-        self._ChannelStrip__v_pot_display_mode = VPOT_DISPLAY_SINGLE_DOT
-        self._ChannelStrip__fader_parameter = None
-        self._ChannelStrip__meters_enabled = False
-        self._ChannelStrip__last_meter_value = -1
-        self._ChannelStrip__send_meter_mode()
-        self._ChannelStrip__within_track_added_or_deleted = False
-        self._ChannelStrip__within_destroy = False
-        self.set_bank_and_channel_offset(offset=0,
-          show_return_tracks=False,
-          within_track_added_or_deleted=False)
+        self.__channel_strip_controller = None
+        self.__is_touched = False
+        self.__strip_index = strip_index
+        self.__stack_offset = 0
+        self.__bank_and_channel_offset = 0
+        self.__assigned_track = None
+        self.__v_pot_parameter = None
+        self.__v_pot_display_mode = VPOT_DISPLAY_SINGLE_DOT
+        self.__fader_parameter = None
+        self.__meters_enabled = False
+        self.__last_meter_value = -1
+        self.__send_meter_mode()
+        self.__within_track_added_or_deleted = False
+        self.__within_destroy = False
+        self.set_bank_and_channel_offset(offset=0, show_return_tracks=False,
+                                         within_track_added_or_deleted=False)
 
     def destroy(self):
-        self._ChannelStrip__within_destroy = True
-        if self._ChannelStrip__assigned_track:
-            self._ChannelStrip__remove_listeners()
-        self._ChannelStrip__assigned_track = None
-        self.send_midi((208, 0 + (self._ChannelStrip__strip_index << 4)))
-        self._ChannelStrip__meters_enabled = False
-        self._ChannelStrip__send_meter_mode()
+        self.__within_destroy = True
+        if self.__assigned_track:
+            self.__remove_listeners()
+        self.__assigned_track = None
+        self.send_midi((208, 0 + (self.__strip_index << 4)))
+        self.__meters_enabled = False
+        self.__send_meter_mode()
         self.refresh_state()
         MackieControlComponent.destroy(self)
-        self._ChannelStrip__within_destroy = False
+        self.__within_destroy = False
 
     def set_channel_strip_controller(self, channel_strip_controller):
-        self._ChannelStrip__channel_strip_controller = channel_strip_controller
+        self.__channel_strip_controller = channel_strip_controller
 
     def strip_index(self):
-        return self._ChannelStrip__strip_index
+        return self.__strip_index
 
     def assigned_track(self):
-        return self._ChannelStrip__assigned_track
+        return self.__assigned_track
 
     def is_touched(self):
-        return self._ChannelStrip__is_touched
+        return self.__is_touched
 
     def set_is_touched(self, touched):
-        self._ChannelStrip__is_touched = touched
+        self.__is_touched = touched
 
     def stack_offset(self):
-        return self._ChannelStrip__stack_offset
+        return self.__stack_offset
 
     def set_stack_offset(self, offset):
-        self._ChannelStrip__stack_offset = offset
+        u"""
+            This is the offset that one gets by 'stacking' several MackieControl XTs:
+            the first is at index 0, the second at 8, etc ...
+        """
+        self.__stack_offset = offset
 
-    def set_bank_and_channel_offset(self, offset, show_return_tracks, within_track_added_or_deleted):
-        final_track_index = self._ChannelStrip__strip_index + self._ChannelStrip__stack_offset + offset
-        self._ChannelStrip__within_track_added_or_deleted = within_track_added_or_deleted
+    def set_bank_and_channel_offset(self, offset, show_return_tracks,
+        within_track_added_or_deleted):
+        final_track_index = self.__strip_index + self.__stack_offset + offset
+        self.__within_track_added_or_deleted = within_track_added_or_deleted
         if show_return_tracks:
             tracks = self.song().return_tracks
         else:
@@ -76,275 +79,305 @@ class ChannelStrip(MackieControlComponent):
             new_track = tracks[final_track_index]
         else:
             new_track = None
-        if new_track != self._ChannelStrip__assigned_track:
-            if self._ChannelStrip__assigned_track:
-                self._ChannelStrip__remove_listeners()
-            self._ChannelStrip__assigned_track = new_track
-            if self._ChannelStrip__assigned_track:
-                self._ChannelStrip__add_listeners()
+        if new_track != self.__assigned_track:
+            if self.__assigned_track:
+                self.__remove_listeners()
+            self.__assigned_track = new_track
+            if self.__assigned_track:
+                self.__add_listeners()
         self.refresh_state()
-        self._ChannelStrip__within_track_added_or_deleted = False
+        self.__within_track_added_or_deleted = False
 
     def v_pot_parameter(self):
-        return self._ChannelStrip__v_pot_parameter
+        return self.__v_pot_parameter
 
-    def set_v_pot_parameter(self, parameter, display_mode=VPOT_DISPLAY_SINGLE_DOT):
-        self._ChannelStrip__v_pot_display_mode = display_mode
-        self._ChannelStrip__v_pot_parameter = parameter
+    def set_v_pot_parameter(self, parameter,
+        display_mode=VPOT_DISPLAY_SINGLE_DOT):
+        self.__v_pot_display_mode = display_mode
+        self.__v_pot_parameter = parameter
         if not parameter:
             self.unlight_vpot_leds()
 
     def fader_parameter(self):
-        return self._ChannelStrip__fader_parameter
+        return self.__fader_parameter
 
     def set_fader_parameter(self, parameter):
-        self._ChannelStrip__fader_parameter = parameter
+        self.__fader_parameter = parameter
         if not parameter:
             self.reset_fader()
 
     def enable_meter_mode(self, Enabled, needs_to_send_meter_mode=True):
-        self._ChannelStrip__meters_enabled = Enabled
+        self.__meters_enabled = Enabled
         if needs_to_send_meter_mode or Enabled:
-            self._ChannelStrip__send_meter_mode()
+            self.__send_meter_mode()
 
     def reset_fader(self):
-        self.send_midi((PB_STATUS + self._ChannelStrip__strip_index, 0, 0))
+        self.send_midi((PB_STATUS + self.__strip_index, 0, 0))
 
     def unlight_vpot_leds(self):
-        self.send_midi((CC_STATUS + 0, 48 + self._ChannelStrip__strip_index, 32))
+        self.send_midi((CC_STATUS + 0, 48 + self.__strip_index, 32))
 
     def show_full_enlighted_poti(self):
-        self.send_midi((
-         CC_STATUS + 0, 48 + self._ChannelStrip__strip_index, VPOT_DISPLAY_WRAP * 16 + 11))
+        self.send_midi((CC_STATUS + 0, 48 + self.__strip_index,
+                        VPOT_DISPLAY_WRAP * 16 + 11))
 
     def handle_channel_strip_switch_ids(self, sw_id, value):
-        if sw_id in range(SID_RECORD_ARM_BASE, SID_RECORD_ARM_BASE + NUM_CHANNEL_STRIPS):
-            if sw_id - SID_RECORD_ARM_BASE is self._ChannelStrip__strip_index:
+        if sw_id in range(SID_RECORD_ARM_BASE,
+                          SID_RECORD_ARM_BASE + NUM_CHANNEL_STRIPS):
+            if sw_id - SID_RECORD_ARM_BASE is self.__strip_index:
                 if value == BUTTON_PRESSED:
                     if self.song().exclusive_arm:
                         exclusive = not self.control_is_pressed()
                     else:
                         exclusive = self.control_is_pressed()
-                    self._ChannelStrip__toggle_arm_track(exclusive)
-        else:
-            if sw_id in range(SID_SOLO_BASE, SID_SOLO_BASE + NUM_CHANNEL_STRIPS):
-                if sw_id - SID_SOLO_BASE is self._ChannelStrip__strip_index:
-                    if value == BUTTON_PRESSED:
-                        if self.song().exclusive_solo:
-                            exclusive = not self.control_is_pressed()
-                        else:
-                            exclusive = self.control_is_pressed()
-                        self._ChannelStrip__toggle_solo_track(exclusive)
-            else:
-                if sw_id in range(SID_MUTE_BASE, SID_MUTE_BASE + NUM_CHANNEL_STRIPS):
-                    if sw_id - SID_MUTE_BASE is self._ChannelStrip__strip_index:
-                        if value == BUTTON_PRESSED:
-                            self._ChannelStrip__toggle_mute_track()
-                else:
-                    if sw_id in range(SID_SELECT_BASE, SID_SELECT_BASE + NUM_CHANNEL_STRIPS):
-                        if sw_id - SID_SELECT_BASE is self._ChannelStrip__strip_index and value == BUTTON_PRESSED:
-                            self._ChannelStrip__select_track()
-                    elif sw_id in range(SID_VPOD_PUSH_BASE, SID_VPOD_PUSH_BASE + NUM_CHANNEL_STRIPS):
-                        if sw_id - SID_VPOD_PUSH_BASE is self._ChannelStrip__strip_index and value == BUTTON_PRESSED and self._ChannelStrip__channel_strip_controller != None:
-                            self._ChannelStrip__channel_strip_controller.handle_pressed_v_pot(self._ChannelStrip__strip_index, self._ChannelStrip__stack_offset)
-                    elif sw_id in fader_touch_switch_ids and sw_id - SID_FADER_TOUCH_SENSE_BASE is self._ChannelStrip__strip_index and not value == BUTTON_PRESSED:
-                        if value == BUTTON_RELEASED:
-                            if self._ChannelStrip__channel_strip_controller != None:
-                                touched = value == BUTTON_PRESSED
-                                self.set_is_touched(touched)
-                                self._ChannelStrip__channel_strip_controller.handle_fader_touch(self._ChannelStrip__strip_index, self._ChannelStrip__stack_offset, touched)
+                    self.__toggle_arm_track(exclusive)
+        elif sw_id in range(SID_SOLO_BASE, SID_SOLO_BASE + NUM_CHANNEL_STRIPS):
+            if sw_id - SID_SOLO_BASE is self.__strip_index:
+                if value == BUTTON_PRESSED:
+                    if self.song().exclusive_solo:
+                        exclusive = not self.control_is_pressed()
+                    else:
+                        exclusive = self.control_is_pressed()
+                    self.__toggle_solo_track(exclusive)
+        elif sw_id in range(SID_MUTE_BASE, SID_MUTE_BASE + NUM_CHANNEL_STRIPS):
+            if sw_id - SID_MUTE_BASE is self.__strip_index:
+                if value == BUTTON_PRESSED:
+                    self.__toggle_mute_track()
+        elif sw_id in range(SID_SELECT_BASE,
+                            SID_SELECT_BASE + NUM_CHANNEL_STRIPS):
+            if sw_id - SID_SELECT_BASE is self.__strip_index:
+                if value == BUTTON_PRESSED:
+                    self.__select_track()
+        elif sw_id in range(SID_VPOD_PUSH_BASE,
+                            SID_VPOD_PUSH_BASE + NUM_CHANNEL_STRIPS):
+            if sw_id - SID_VPOD_PUSH_BASE is self.__strip_index:
+                if value == BUTTON_PRESSED and self.__channel_strip_controller != None:
+                    self.__channel_strip_controller.handle_pressed_v_pot(
+                        self.__strip_index, self.__stack_offset)
+        elif sw_id in fader_touch_switch_ids:
+            if sw_id - SID_FADER_TOUCH_SENSE_BASE is self.__strip_index:
+                if value == BUTTON_PRESSED or value == BUTTON_RELEASED:
+                    if self.__channel_strip_controller != None:
+                        touched = value == BUTTON_PRESSED
+                        self.set_is_touched(touched)
+                        self.__channel_strip_controller.handle_fader_touch(
+                            self.__strip_index, self.__stack_offset, touched)
 
     def handle_vpot_rotation(self, strip_index, cc_value):
-        if strip_index is self._ChannelStrip__strip_index:
-            if self._ChannelStrip__channel_strip_controller != None:
-                self._ChannelStrip__channel_strip_controller.handle_vpot_rotation(self._ChannelStrip__strip_index, self._ChannelStrip__stack_offset, cc_value)
+        if strip_index is self.__strip_index and self.__channel_strip_controller != None:
+            self.__channel_strip_controller.handle_vpot_rotation(
+                self.__strip_index, self.__stack_offset, cc_value)
 
     def refresh_state(self):
-        if not self._ChannelStrip__within_track_added_or_deleted:
-            self._ChannelStrip__update_track_is_selected_led()
-        else:
-            self._ChannelStrip__update_solo_led()
-            self._ChannelStrip__update_mute_led()
-            self._ChannelStrip__update_arm_led()
-            if not self._ChannelStrip__within_destroy:
-                if self._ChannelStrip__assigned_track != None:
-                    self._ChannelStrip__send_meter_mode()
-                    self._ChannelStrip__last_meter_value = -1
-            self._ChannelStrip__assigned_track or self.reset_fader()
+        if not self.__within_track_added_or_deleted:
+            self.__update_track_is_selected_led()
+        self.__update_solo_led()
+        self.__update_mute_led()
+        self.__update_arm_led()
+        if not self.__within_destroy and self.__assigned_track != None:
+            self.__send_meter_mode()
+            self.__last_meter_value = -1
+        if not self.__assigned_track:
+            self.reset_fader()
             self.unlight_vpot_leds()
 
     def on_update_display_timer(self):
-        if self.main_script().is_pro_version:
-            if not self._ChannelStrip__meters_enabled or self._ChannelStrip__channel_strip_controller.assignment_mode() == CSM_VOLPAN:
-                if self._ChannelStrip__assigned_track:
-                    if self._ChannelStrip__assigned_track.can_be_armed and self._ChannelStrip__assigned_track.arm:
-                        meter_value = self._ChannelStrip__assigned_track.input_meter_level
-                    else:
-                        meter_value = self._ChannelStrip__assigned_track.output_meter_level
+        if not self.main_script().is_pro_version or self.__meters_enabled and self.__channel_strip_controller.assignment_mode() == CSM_VOLPAN:
+            if self.__assigned_track:
+                if self.__assigned_track.can_be_armed and self.__assigned_track.arm:
+                    meter_value = self.__assigned_track.input_meter_level
                 else:
-                    meter_value = 0.0
-        else:
-            meter_byte = int(meter_value * 12.0) + (self._ChannelStrip__strip_index << 4)
-            if self._ChannelStrip__last_meter_value != meter_value or meter_value != 0.0:
-                self._ChannelStrip__last_meter_value = meter_value
+                    meter_value = self.__assigned_track.output_meter_level
+            else:
+                meter_value = 0.0
+            meter_byte = int(meter_value * 12.0) + (self.__strip_index << 4)
+            if self.__last_meter_value != meter_value or meter_value != 0.0:
+                self.__last_meter_value = meter_value
                 self.send_midi((208, meter_byte))
 
     def build_midi_map(self, midi_map_handle):
         needs_takeover = False
-        if self._ChannelStrip__fader_parameter:
+        if self.__fader_parameter:
             feeback_rule = Live.MidiMap.PitchBendFeedbackRule()
-            feeback_rule.channel = self._ChannelStrip__strip_index
+            feeback_rule.channel = self.__strip_index
             feeback_rule.value_pair_map = tuple()
             feeback_rule.delay_in_ms = 200.0
-            Live.MidiMap.map_midi_pitchbend_with_feedback_map(midi_map_handle, self._ChannelStrip__fader_parameter, self._ChannelStrip__strip_index, feeback_rule, not needs_takeover)
-            Live.MidiMap.send_feedback_for_parameter(midi_map_handle, self._ChannelStrip__fader_parameter)
+            Live.MidiMap.map_midi_pitchbend_with_feedback_map(midi_map_handle,
+                                                              self.__fader_parameter,
+                                                              self.__strip_index,
+                                                              feeback_rule,
+                                                              not needs_takeover)
+            Live.MidiMap.send_feedback_for_parameter(midi_map_handle,
+                                                     self.__fader_parameter)
         else:
-            channel = self._ChannelStrip__strip_index
-            Live.MidiMap.forward_midi_pitchbend(self.script_handle(), midi_map_handle, channel)
-        if self._ChannelStrip__v_pot_parameter:
-            if self._ChannelStrip__v_pot_display_mode == VPOT_DISPLAY_SPREAD:
+            channel = self.__strip_index
+            Live.MidiMap.forward_midi_pitchbend(self.script_handle(),
+                                                midi_map_handle, channel)
+        if self.__v_pot_parameter:
+            if self.__v_pot_display_mode == VPOT_DISPLAY_SPREAD:
                 range_end = 7
             else:
                 range_end = 12
             feeback_rule = Live.MidiMap.CCFeedbackRule()
             feeback_rule.channel = 0
-            feeback_rule.cc_no = 48 + self._ChannelStrip__strip_index
-            feeback_rule.cc_value_map = tuple([self._ChannelStrip__v_pot_display_mode * 16 + x for x in range(1, range_end)])
+            feeback_rule.cc_no = 48 + self.__strip_index
+            feeback_rule.cc_value_map = tuple(
+                [self.__v_pot_display_mode * 16 + x for x in
+                 range(1, range_end)])
             feeback_rule.delay_in_ms = -1.0
-            Live.MidiMap.map_midi_cc_with_feedback_map(midi_map_handle, self._ChannelStrip__v_pot_parameter, 0, FID_PANNING_BASE + self._ChannelStrip__strip_index, Live.MidiMap.MapMode.relative_signed_bit, feeback_rule, needs_takeover)
-            Live.MidiMap.send_feedback_for_parameter(midi_map_handle, self._ChannelStrip__v_pot_parameter)
+            Live.MidiMap.map_midi_cc_with_feedback_map(midi_map_handle,
+                                                       self.__v_pot_parameter,
+                                                       0,
+                                                       FID_PANNING_BASE + self.__strip_index,
+                                                       Live.MidiMap.MapMode.relative_signed_bit,
+                                                       feeback_rule,
+                                                       needs_takeover)
+            Live.MidiMap.send_feedback_for_parameter(midi_map_handle,
+                                                     self.__v_pot_parameter)
         else:
             channel = 0
-            cc_no = FID_PANNING_BASE + self._ChannelStrip__strip_index
-            Live.MidiMap.forward_midi_cc(self.script_handle(), midi_map_handle, channel, cc_no)
+            cc_no = FID_PANNING_BASE + self.__strip_index
+            Live.MidiMap.forward_midi_cc(self.script_handle(), midi_map_handle,
+                                         channel, cc_no)
 
     def __assigned_track_index(self):
         index = 0
+
         for t in chain(self.song().visible_tracks, self.song().return_tracks):
-            if t == self._ChannelStrip__assigned_track:
+            if t == self.__assigned_track:
                 return index
             index += 1
 
-        if self._ChannelStrip__assigned_track:
+        if self.__assigned_track:
             pass
+        return None
 
     def __add_listeners(self):
-        if self._ChannelStrip__assigned_track:
-            if self._ChannelStrip__assigned_track in self.song().tracks:
-                self._ChannelStrip__assigned_track.add_input_routing_type_listener(self._ChannelStrip__update_arm_led)
-                if self._ChannelStrip__assigned_track.can_be_armed:
-                    self._ChannelStrip__assigned_track.add_arm_listener(self._ChannelStrip__update_arm_led)
-        self._ChannelStrip__assigned_track.add_mute_listener(self._ChannelStrip__update_mute_led)
-        self._ChannelStrip__assigned_track.add_solo_listener(self._ChannelStrip__update_solo_led)
-        if not self.song().view.selected_track_has_listener(self._ChannelStrip__update_track_is_selected_led):
-            self.song().view.add_selected_track_listener(self._ChannelStrip__update_track_is_selected_led)
+
+        if self.__assigned_track and self.__assigned_track in self.song().tracks:
+            self.__assigned_track.add_input_routing_type_listener(
+                self.__update_arm_led)
+            if self.__assigned_track.can_be_armed:
+                self.__assigned_track.add_arm_listener(self.__update_arm_led)
+        self.__assigned_track.add_mute_listener(self.__update_mute_led)
+        self.__assigned_track.add_solo_listener(self.__update_solo_led)
+        if not self.song().view.selected_track_has_listener(
+            self.__update_track_is_selected_led):
+            self.song().view.add_selected_track_listener(
+                self.__update_track_is_selected_led)
 
     def __remove_listeners(self):
-        if liveobj_valid(self._ChannelStrip__assigned_track):
-            if self._ChannelStrip__assigned_track in self.song().tracks:
-                self._ChannelStrip__remove_listener(self._ChannelStrip__assigned_track, "input_routing_type", self._ChannelStrip__update_arm_led)
-                if self._ChannelStrip__assigned_track.can_be_armed:
-                    self._ChannelStrip__remove_listener(self._ChannelStrip__assigned_track, "arm", self._ChannelStrip__update_arm_led)
-            self._ChannelStrip__remove_listener(self._ChannelStrip__assigned_track, "mute", self._ChannelStrip__update_mute_led)
-            self._ChannelStrip__remove_listener(self._ChannelStrip__assigned_track, "solo", self._ChannelStrip__update_solo_led)
-            self._ChannelStrip__remove_listener(self.song().view, "selected_track", self._ChannelStrip__update_track_is_selected_led)
+        if liveobj_valid(self.__assigned_track):
+            if self.__assigned_track in self.song().tracks:
+                self.__remove_listener(self.__assigned_track,
+                                       'input_routing_type',
+                                       self.__update_arm_led)
+                if self.__assigned_track.can_be_armed:
+                    self.__remove_listener(self.__assigned_track, 'arm',
+                                           self.__update_arm_led)
+            self.__remove_listener(self.__assigned_track, 'mute',
+                                   self.__update_mute_led)
+            self.__remove_listener(self.__assigned_track, 'solo',
+                                   self.__update_solo_led)
+            self.__remove_listener(self.song().view, 'selected_track',
+                                   self.__update_track_is_selected_led)
 
     def __remove_listener(self, object, property, listener):
-        if getattr(object, "{}_has_listener".format(property))(listener):
-            getattr(object, "remove_{}_listener".format(property))(listener)
+        if getattr(object, u'{}_has_listener'.format(property))(listener):
+            getattr(object, u'remove_{}_listener'.format(property))(listener)
 
     def __send_meter_mode(self):
         on_mode = 1
         off_mode = 0
-        if self._ChannelStrip__meters_enabled:
+        if self.__meters_enabled:
             on_mode = on_mode | 2
+        if self.__assigned_track:
+            mode = on_mode
         else:
-            if self._ChannelStrip__assigned_track:
-                mode = on_mode
-            else:
-                mode = off_mode
-            if self.main_script().is_extension():
-                device_type = SYSEX_DEVICE_TYPE_XT
-            else:
-                device_type = SYSEX_DEVICE_TYPE
-        self.send_midi((
-         240, 0, 0, 102, device_type, 32, self._ChannelStrip__strip_index, mode, 247))
+            mode = off_mode
+        if self.main_script().is_extension():
+            device_type = SYSEX_DEVICE_TYPE_XT
+        else:
+            device_type = SYSEX_DEVICE_TYPE
+        self.send_midi(
+            (240, 0, 0, 102, device_type, 32, self.__strip_index, mode, 247))
 
     def __toggle_arm_track(self, exclusive):
-        if self._ChannelStrip__assigned_track:
-            if self._ChannelStrip__assigned_track.can_be_armed:
-                self._ChannelStrip__assigned_track.arm = not self._ChannelStrip__assigned_track.arm
-                if exclusive:
-                    for t in self.song().tracks:
-                        if t != self._ChannelStrip__assigned_track and t.can_be_armed:
-                            t.arm = False
+        if self.__assigned_track and self.__assigned_track.can_be_armed:
+            self.__assigned_track.arm = not self.__assigned_track.arm
+            if exclusive:
+                for t in self.song().tracks:
+                    if t != self.__assigned_track and t.can_be_armed:
+                        t.arm = False
 
     def __toggle_mute_track(self):
-        if self._ChannelStrip__assigned_track:
-            self._ChannelStrip__assigned_track.mute = not self._ChannelStrip__assigned_track.mute
+        if self.__assigned_track:
+            self.__assigned_track.mute = not self.__assigned_track.mute
 
     def __toggle_solo_track(self, exclusive):
-        if self._ChannelStrip__assigned_track:
-            self._ChannelStrip__assigned_track.solo = not self._ChannelStrip__assigned_track.solo
+        if self.__assigned_track:
+            self.__assigned_track.solo = not self.__assigned_track.solo
             if exclusive:
                 for t in chain(self.song().tracks, self.song().return_tracks):
-                    if t != self._ChannelStrip__assigned_track:
+                    if t != self.__assigned_track:
                         t.solo = False
 
     def __select_track(self):
-        if self._ChannelStrip__assigned_track:
-            all_tracks = tuple(self.song().visible_tracks) + tuple(self.song().return_tracks)
-            if self.song().view.selected_track != all_tracks[self._ChannelStrip__assigned_track_index()]:
-                self.song().view.selected_track = all_tracks[self._ChannelStrip__assigned_track_index()]
-            else:
-                if self.application().view.is_view_visible("Arranger"):
-                    if self._ChannelStrip__assigned_track:
-                        self._ChannelStrip__assigned_track.view.is_collapsed = not self._ChannelStrip__assigned_track.view.is_collapsed
+        if self.__assigned_track:
+            all_tracks = tuple(self.song().visible_tracks) + tuple(
+                self.song().return_tracks)
+            if self.song().view.selected_track != all_tracks[
+                self.__assigned_track_index()]:
+                self.song().view.selected_track = all_tracks[
+                    self.__assigned_track_index()]
+            elif self.application().view.is_view_visible(u'Arranger'):
+                if self.__assigned_track:
+                    self.__assigned_track.view.is_collapsed = not self.__assigned_track.view.is_collapsed
 
     def __update_arm_led(self):
-        track = self._ChannelStrip__assigned_track
+        track = self.__assigned_track
         if track and track.can_be_armed and track.arm:
-            self.send_midi((
-             NOTE_ON_STATUS,
-             SID_RECORD_ARM_BASE + self._ChannelStrip__strip_index,
-             BUTTON_STATE_ON))
+            self.send_midi((NOTE_ON_STATUS,
+                            SID_RECORD_ARM_BASE + self.__strip_index,
+                            BUTTON_STATE_ON))
         else:
-            self.send_midi((
-             NOTE_ON_STATUS,
-             SID_RECORD_ARM_BASE + self._ChannelStrip__strip_index,
-             BUTTON_STATE_OFF))
+            self.send_midi((NOTE_ON_STATUS,
+                            SID_RECORD_ARM_BASE + self.__strip_index,
+                            BUTTON_STATE_OFF))
 
     def __update_mute_led(self):
-        if self._ChannelStrip__assigned_track and self._ChannelStrip__assigned_track.mute:
-            self.send_midi((
-             NOTE_ON_STATUS, SID_MUTE_BASE + self._ChannelStrip__strip_index, BUTTON_STATE_ON))
+        if self.__assigned_track and self.__assigned_track.mute:
+            self.send_midi((NOTE_ON_STATUS, SID_MUTE_BASE + self.__strip_index,
+                            BUTTON_STATE_ON))
         else:
-            self.send_midi((
-             NOTE_ON_STATUS, SID_MUTE_BASE + self._ChannelStrip__strip_index, BUTTON_STATE_OFF))
+            self.send_midi((NOTE_ON_STATUS, SID_MUTE_BASE + self.__strip_index,
+                            BUTTON_STATE_OFF))
 
     def __update_solo_led(self):
-        if self._ChannelStrip__assigned_track and self._ChannelStrip__assigned_track.solo:
-            self.send_midi((
-             NOTE_ON_STATUS, SID_SOLO_BASE + self._ChannelStrip__strip_index, BUTTON_STATE_ON))
+        if self.__assigned_track and self.__assigned_track.solo:
+            self.send_midi((NOTE_ON_STATUS, SID_SOLO_BASE + self.__strip_index,
+                            BUTTON_STATE_ON))
         else:
-            self.send_midi((
-             NOTE_ON_STATUS, SID_SOLO_BASE + self._ChannelStrip__strip_index, BUTTON_STATE_OFF))
+            self.send_midi((NOTE_ON_STATUS, SID_SOLO_BASE + self.__strip_index,
+                            BUTTON_STATE_OFF))
 
     def __update_track_is_selected_led(self):
-        if self.song().view.selected_track == self._ChannelStrip__assigned_track:
+        if self.song().view.selected_track == self.__assigned_track:
             self.send_midi((
-             NOTE_ON_STATUS, SID_SELECT_BASE + self._ChannelStrip__strip_index, BUTTON_STATE_ON))
+                           NOTE_ON_STATUS, SID_SELECT_BASE + self.__strip_index,
+                           BUTTON_STATE_ON))
         else:
             self.send_midi((
-             NOTE_ON_STATUS, SID_SELECT_BASE + self._ChannelStrip__strip_index, BUTTON_STATE_OFF))
+                           NOTE_ON_STATUS, SID_SELECT_BASE + self.__strip_index,
+                           BUTTON_STATE_OFF))
 
 
 class MasterChannelStrip(MackieControlComponent):
 
     def __init__(self, main_script):
         MackieControlComponent.__init__(self, main_script)
-        self._MasterChannelStrip__strip_index = MASTER_CHANNEL_STRIP_INDEX
-        self._MasterChannelStrip__assigned_track = self.song().master_track
+        self.__strip_index = MASTER_CHANNEL_STRIP_INDEX
+        self.__assigned_track = self.song().master_track
 
     def destroy(self):
         self.reset_fader()
@@ -366,15 +399,19 @@ class MasterChannelStrip(MackieControlComponent):
         pass
 
     def reset_fader(self):
-        self.send_midi((PB_STATUS + self._MasterChannelStrip__strip_index, 0, 0))
+        self.send_midi((PB_STATUS + self.__strip_index, 0, 0))
 
     def build_midi_map(self, midi_map_handle):
-        if self._MasterChannelStrip__assigned_track:
+        if self.__assigned_track:
             needs_takeover = False
-            volume = self._MasterChannelStrip__assigned_track.mixer_device.volume
+            volume = self.__assigned_track.mixer_device.volume
             feeback_rule = Live.MidiMap.PitchBendFeedbackRule()
-            feeback_rule.channel = self._MasterChannelStrip__strip_index
+            feeback_rule.channel = self.__strip_index
             feeback_rule.value_pair_map = tuple()
             feeback_rule.delay_in_ms = 200.0
-            Live.MidiMap.map_midi_pitchbend_with_feedback_map(midi_map_handle, volume, self._MasterChannelStrip__strip_index, feeback_rule, not needs_takeover)
+            Live.MidiMap.map_midi_pitchbend_with_feedback_map(midi_map_handle,
+                                                              volume,
+                                                              self.__strip_index,
+                                                              feeback_rule,
+                                                              not needs_takeover)
             Live.MidiMap.send_feedback_for_parameter(midi_map_handle, volume)

--- a/MackieControl/ChannelStripController.py
+++ b/MackieControl/ChannelStripController.py
@@ -5,8 +5,6 @@
 
 from itertools import chain
 
-from past.utils import old_div
-
 from _Generic.Devices import *
 from .MackieControlComponent import *
 
@@ -174,9 +172,9 @@ class ChannelStripController(MackieControlComponent):
         elif switch_id == SID_FADERBANK_NEXT_BANK:
             if value == BUTTON_PRESSED:
                 if self.shift_is_pressed():
-                    last_possible_offset = old_div(
-                        self.__controlled_num_of_tracks() - self.__strip_offset(),
-                        len(self.__channel_strips)) * len(
+                    last_possible_offset = ((
+                                                    self.__controlled_num_of_tracks() - self.__strip_offset()) // len(
+                        self.__channel_strips)) * len(
                         self.__channel_strips) + self.__strip_offset()
                     if last_possible_offset == self.__controlled_num_of_tracks():
                         last_possible_offset -= len(self.__channel_strips)
@@ -263,7 +261,7 @@ class ChannelStripController(MackieControlComponent):
                         self.__chosen_plugin.remove_parameters_listener(
                             self.__on_parameter_list_of_chosen_plugin_changed)
                     self.__chosen_plugin = \
-                    self.song().view.selected_track.devices[device_index]
+                        self.song().view.selected_track.devices[device_index]
                     if self.__chosen_plugin != None:
                         self.__chosen_plugin.add_parameters_listener(
                             self.__on_parameter_list_of_chosen_plugin_changed)
@@ -504,10 +502,10 @@ class ChannelStripController(MackieControlComponent):
             if self.__assignment_mode == CSM_VOLPAN:
                 if s.assigned_track() and s.assigned_track().has_audio_output:
                     vpot_param = (
-                    s.assigned_track().mixer_device.panning, 'Pan')
+                        s.assigned_track().mixer_device.panning, 'Pan')
                     vpot_display_mode = VPOT_DISPLAY_BOOST_CUT
                     slider_param = (
-                    s.assigned_track().mixer_device.volume, 'Volume')
+                        s.assigned_track().mixer_device.volume, 'Volume')
                     slider_display_mode = VPOT_DISPLAY_WRAP
             elif self.__assignment_mode == CSM_PLUGINS:
                 vpot_param = self.__plugin_parameter(s.strip_index(),
@@ -515,7 +513,7 @@ class ChannelStripController(MackieControlComponent):
                 vpot_display_mode = VPOT_DISPLAY_WRAP
                 if s.assigned_track() and s.assigned_track().has_audio_output:
                     slider_param = (
-                    s.assigned_track().mixer_device.volume, 'Volume')
+                        s.assigned_track().mixer_device.volume, 'Volume')
                     slider_display_mode = VPOT_DISPLAY_WRAP
             elif self.__assignment_mode == CSM_SENDS:
                 vpot_param = self.__send_parameter(s.strip_index(),
@@ -523,11 +521,11 @@ class ChannelStripController(MackieControlComponent):
                 vpot_display_mode = VPOT_DISPLAY_WRAP
                 if s.assigned_track() and s.assigned_track().has_audio_output:
                     slider_param = (
-                    s.assigned_track().mixer_device.volume, 'Volume')
+                        s.assigned_track().mixer_device.volume, 'Volume')
                     slider_display_mode = VPOT_DISPLAY_WRAP
             elif self.__assignment_mode == CSM_IO and s.assigned_track() and s.assigned_track().has_audio_output:
                 slider_param = (
-                s.assigned_track().mixer_device.volume, 'Volume')
+                    s.assigned_track().mixer_device.volume, 'Volume')
             if self.__flip and self.__can_flip():
                 if self.__any_slider_is_touched():
                     display_parameters.append(vpot_param)

--- a/MackieControl/ChannelStripController.py
+++ b/MackieControl/ChannelStripController.py
@@ -1,221 +1,222 @@
-# uncompyle6 version 3.9.1
-# Python bytecode version base 3.7.0 (3394)
-# Decompiled from: Python 3.12.2 (main, Feb  6 2024, 20:19:44) [Clang 15.0.0 (clang-1500.1.0.2.5)]
-# Embedded file name: output/Live/mac_universal_64_static/Release/python-bundle/MIDI Remote Scripts/MackieControl/ChannelStripController.py
-# Compiled at: 2024-03-09 01:30:22
-# Size of source mod 2**32: 52363 bytes
-from __future__ import absolute_import, division, print_function, unicode_literals
-from builtins import chr, range
-from past.utils import old_div
+# Decompiled with PyLingual (https://pylingual.io)
+# Internal filename: ..\..\..\output\Live\win_64_static\Release\python-bundle\MIDI Remote Scripts\MackieControl\ChannelStripController.py
+# Bytecode version: 3.11a7e (3495)
+# Source timestamp: 2024-09-26 15:27:47 UTC (1727364467)
+
 from itertools import chain
+
+from past.utils import old_div
+
 from _Generic.Devices import *
 from .MackieControlComponent import *
+
 flatten_target = lambda routing_target: routing_target.display_name
 
+
 def flatten_target_list(target_list):
+    pass
     target_names = []
     for target in target_list:
         name = flatten_target(target)
         if name not in target_names:
             target_names.append(name)
-
     return target_names
 
 
 def target_by_name(target_list, name):
+    pass
     matches = [t for t in target_list if t.display_name == name]
-    if matches:
-        return matches[0]
+    return matches[0] if matches else None
 
 
 class ChannelStripController(MackieControlComponent):
+    pass
 
-    def __init__(self, main_script, channel_strips, master_strip, main_display_controller):
+    def __init__(self, main_script, channel_strips, master_strip,
+        main_display_controller):
         MackieControlComponent.__init__(self, main_script)
-        self._ChannelStripController__left_extensions = []
-        self._ChannelStripController__right_extensions = []
-        self._ChannelStripController__own_channel_strips = channel_strips
-        self._ChannelStripController__master_strip = master_strip
-        self._ChannelStripController__channel_strips = channel_strips
-        self._ChannelStripController__main_display_controller = main_display_controller
-        self._ChannelStripController__meters_enabled = False
-        self._ChannelStripController__assignment_mode = CSM_VOLPAN
-        self._ChannelStripController__sub_mode_in_io_mode = CSM_IO_FIRST_MODE
-        self._ChannelStripController__plugin_mode = PCM_DEVICES
-        self._ChannelStripController__plugin_mode_offsets = [0 for x in range(PCM_NUMMODES)]
-        self._ChannelStripController__chosen_plugin = None
-        self._ChannelStripController__ordered_plugin_parameters = []
-        self._ChannelStripController__displayed_plugins = []
-        self._ChannelStripController__last_attached_selected_track = None
-        self._ChannelStripController__send_mode_offset = 0
-        self._ChannelStripController__flip = False
-        self._ChannelStripController__view_returns = False
-        self._ChannelStripController__bank_cha_offset = 0
-        self._ChannelStripController__bank_cha_offset_returns = 0
-        self._ChannelStripController__within_track_added_or_deleted = False
-        self.song().add_visible_tracks_listener(self._ChannelStripController__on_tracks_added_or_deleted)
-        self.song().view.add_selected_track_listener(self._ChannelStripController__on_selected_track_changed)
+        self.__left_extensions = []
+        self.__right_extensions = []
+        self.__own_channel_strips = channel_strips
+        self.__master_strip = master_strip
+        self.__channel_strips = channel_strips
+        self.__main_display_controller = main_display_controller
+        self.__meters_enabled = False
+        self.__assignment_mode = CSM_VOLPAN
+        self.__sub_mode_in_io_mode = CSM_IO_FIRST_MODE
+        self.__plugin_mode = PCM_DEVICES
+        self.__plugin_mode_offsets = [0 for x in range(PCM_NUMMODES)]
+        self.__chosen_plugin = None
+        self.__ordered_plugin_parameters = []
+        self.__displayed_plugins = []
+        self.__last_attached_selected_track = None
+        self.__send_mode_offset = 0
+        self.__flip = False
+        self.__view_returns = False
+        self.__bank_cha_offset = 0
+        self.__bank_cha_offset_returns = 0
+        self.__within_track_added_or_deleted = False
+        self.song().add_visible_tracks_listener(
+            self.__on_tracks_added_or_deleted)
+        self.song().view.add_selected_track_listener(
+            self.__on_selected_track_changed)
         for t in chain(self.song().visible_tracks, self.song().return_tracks):
-            if not t.solo_has_listener(self._ChannelStripController__update_rude_solo_led):
-                t.add_solo_listener(self._ChannelStripController__update_rude_solo_led)
-            if not t.has_audio_output_has_listener(self._ChannelStripController__on_any_tracks_output_type_changed):
-                t.add_has_audio_output_listener(self._ChannelStripController__on_any_tracks_output_type_changed)
-
-        self._ChannelStripController__on_selected_track_changed()
-        for s in self._ChannelStripController__own_channel_strips:
+            if not t.solo_has_listener(self.__update_rude_solo_led):
+                t.add_solo_listener(self.__update_rude_solo_led)
+            if not t.has_audio_output_has_listener(
+                self.__on_any_tracks_output_type_changed):
+                t.add_has_audio_output_listener(
+                    self.__on_any_tracks_output_type_changed)
+        self.__on_selected_track_changed()
+        for s in self.__own_channel_strips:
             s.set_channel_strip_controller(self)
-
-        self._ChannelStripController__reassign_channel_strip_offsets()
-        self._ChannelStripController__reassign_channel_strip_parameters(for_display_only=False)
-        self._last_assignment_mode = self._ChannelStripController__assignment_mode
+        self.__reassign_channel_strip_offsets()
+        self.__reassign_channel_strip_parameters(for_display_only=False)
+        self._last_assignment_mode = self.__assignment_mode
 
     def destroy(self):
-        self.song().remove_visible_tracks_listener(self._ChannelStripController__on_tracks_added_or_deleted)
-        self.song().view.remove_selected_track_listener(self._ChannelStripController__on_selected_track_changed)
+        self.song().remove_visible_tracks_listener(
+            self.__on_tracks_added_or_deleted)
+        self.song().view.remove_selected_track_listener(
+            self.__on_selected_track_changed)
         for t in chain(self.song().visible_tracks, self.song().return_tracks):
-            if t.solo_has_listener(self._ChannelStripController__update_rude_solo_led):
-                t.remove_solo_listener(self._ChannelStripController__update_rude_solo_led)
-            if t.has_audio_output_has_listener(self._ChannelStripController__on_any_tracks_output_type_changed):
-                t.remove_has_audio_output_listener(self._ChannelStripController__on_any_tracks_output_type_changed)
-
-        st = self._ChannelStripController__last_attached_selected_track
-        if st:
-            if st.devices_has_listener(self._ChannelStripController__on_selected_device_chain_changed):
-                st.remove_devices_listener(self._ChannelStripController__on_selected_device_chain_changed)
+            if t.solo_has_listener(self.__update_rude_solo_led):
+                t.remove_solo_listener(self.__update_rude_solo_led)
+            if t.has_audio_output_has_listener(
+                self.__on_any_tracks_output_type_changed):
+                t.remove_has_audio_output_listener(
+                    self.__on_any_tracks_output_type_changed)
+        st = self.__last_attached_selected_track
+        if st and st.devices_has_listener(
+            self.__on_selected_device_chain_changed):
+            st.remove_devices_listener(self.__on_selected_device_chain_changed)
         for note in channel_strip_assignment_switch_ids:
             self.send_midi((NOTE_ON_STATUS, note, BUTTON_STATE_OFF))
-
         for note in channel_strip_control_switch_ids:
             self.send_midi((NOTE_ON_STATUS, note, BUTTON_STATE_OFF))
-
         self.send_midi((NOTE_ON_STATUS, SELECT_RUDE_SOLO, BUTTON_STATE_OFF))
-        self.send_midi((CC_STATUS, 75, g7_seg_led_conv_table[" "]))
-        self.send_midi((CC_STATUS, 74, g7_seg_led_conv_table[" "]))
+        self.send_midi((CC_STATUS, 75, g7_seg_led_conv_table[' ']))
+        self.send_midi((CC_STATUS, 74, g7_seg_led_conv_table[' ']))
         MackieControlComponent.destroy(self)
 
     def set_controller_extensions(self, left_extensions, right_extensions):
-        self._ChannelStripController__left_extensions = left_extensions
-        self._ChannelStripController__right_extensions = right_extensions
-        self._ChannelStripController__channel_strips = []
+        pass
+        self.__left_extensions = left_extensions
+        self.__right_extensions = right_extensions
+        self.__channel_strips = []
         stack_offset = 0
         for le in left_extensions:
             for s in le.channel_strips():
-                self._ChannelStripController__channel_strips.append(s)
+                self.__channel_strips.append(s)
                 s.set_stack_offset(stack_offset)
-
             stack_offset += NUM_CHANNEL_STRIPS
-
-        for s in self._ChannelStripController__own_channel_strips:
-            self._ChannelStripController__channel_strips.append(s)
+        for s in self.__own_channel_strips:
+            self.__channel_strips.append(s)
             s.set_stack_offset(stack_offset)
-
         stack_offset += NUM_CHANNEL_STRIPS
         for re in right_extensions:
             for s in re.channel_strips():
-                self._ChannelStripController__channel_strips.append(s)
+                self.__channel_strips.append(s)
                 s.set_stack_offset(stack_offset)
-
             stack_offset += NUM_CHANNEL_STRIPS
-
-        for s in self._ChannelStripController__channel_strips:
+        for s in self.__channel_strips:
             s.set_channel_strip_controller(self)
-
         self.refresh_state()
 
     def refresh_state(self):
-        self._ChannelStripController__update_assignment_mode_leds()
-        self._ChannelStripController__update_assignment_display()
-        self._ChannelStripController__update_rude_solo_led()
-        self._ChannelStripController__reassign_channel_strip_offsets()
-        self._ChannelStripController__on_flip_changed()
-        self._ChannelStripController__update_view_returns_mode()
+        self.__update_assignment_mode_leds()
+        self.__update_assignment_display()
+        self.__update_rude_solo_led()
+        self.__reassign_channel_strip_offsets()
+        self.__on_flip_changed()
+        self.__update_view_returns_mode()
 
     def request_rebuild_midi_map(self):
+        pass
         MackieControlComponent.request_rebuild_midi_map(self)
-        for ex in self._ChannelStripController__left_extensions + self._ChannelStripController__right_extensions:
+        for ex in self.__left_extensions + self.__right_extensions:
             ex.request_rebuild_midi_map()
 
     def on_update_display_timer(self):
-        self._ChannelStripController__update_channel_strip_strings()
+        self.__update_channel_strip_strings()
 
     def toggle_meter_mode(self):
-        self._ChannelStripController__meters_enabled = not self._ChannelStripController__meters_enabled
-        self._ChannelStripController__apply_meter_mode(meter_state_changed=True)
+        pass
+        self.__meters_enabled = not self.__meters_enabled
+        self.__apply_meter_mode(meter_state_changed=True)
 
     def handle_assignment_switch_ids(self, switch_id, value):
         if switch_id == SID_ASSIGNMENT_IO:
             if value == BUTTON_PRESSED:
-                self._ChannelStripController__set_assignment_mode(CSM_IO)
-        else:
-            if switch_id == SID_ASSIGNMENT_SENDS:
-                if value == BUTTON_PRESSED:
-                    self._ChannelStripController__set_assignment_mode(CSM_SENDS)
-            else:
-                if switch_id == SID_ASSIGNMENT_PAN:
-                    if value == BUTTON_PRESSED:
-                        self._ChannelStripController__set_assignment_mode(CSM_VOLPAN)
-                else:
-                    if switch_id == SID_ASSIGNMENT_PLUG_INS:
-                        if value == BUTTON_PRESSED:
-                            self._ChannelStripController__set_assignment_mode(CSM_PLUGINS)
-                    else:
-                        if switch_id == SID_ASSIGNMENT_EQ:
-                            if value == BUTTON_PRESSED:
-                                self._ChannelStripController__switch_to_prev_page()
-                        else:
-                            if switch_id == SID_ASSIGNMENT_DYNAMIC:
-                                if value == BUTTON_PRESSED:
-                                    self._ChannelStripController__switch_to_next_page()
-                            else:
-                                if switch_id == SID_FADERBANK_PREV_BANK:
-                                    if value == BUTTON_PRESSED:
-                                        if self.shift_is_pressed():
-                                            self._ChannelStripController__set_channel_offset(0)
-                                        else:
-                                            self._ChannelStripController__set_channel_offset(self._ChannelStripController__strip_offset() - len(self._ChannelStripController__channel_strips))
-                                else:
-                                    if switch_id == SID_FADERBANK_NEXT_BANK:
-                                        if value == BUTTON_PRESSED:
-                                            if self.shift_is_pressed():
-                                                last_possible_offset = old_div(self._ChannelStripController__controlled_num_of_tracks() - self._ChannelStripController__strip_offset(), len(self._ChannelStripController__channel_strips)) * len(self._ChannelStripController__channel_strips) + self._ChannelStripController__strip_offset()
-                                                if last_possible_offset == self._ChannelStripController__controlled_num_of_tracks():
-                                                    last_possible_offset -= len(self._ChannelStripController__channel_strips)
-                                                self._ChannelStripController__set_channel_offset(last_possible_offset)
-                                            else:
-                                                if self._ChannelStripController__strip_offset() < self._ChannelStripController__controlled_num_of_tracks() - len(self._ChannelStripController__channel_strips):
-                                                    self._ChannelStripController__set_channel_offset(self._ChannelStripController__strip_offset() + len(self._ChannelStripController__channel_strips))
-                                        else:
-                                            if switch_id == SID_FADERBANK_PREV_CH:
-                                                if value == BUTTON_PRESSED:
-                                                    if self.shift_is_pressed():
-                                                        self._ChannelStripController__set_channel_offset(0)
-                                            else:
-                                                self._ChannelStripController__set_channel_offset(self._ChannelStripController__strip_offset() - 1)
-                                    else:
-                                        pass
-        if switch_id == SID_FADERBANK_NEXT_CH:
+                self.__set_assignment_mode(CSM_IO)
+        elif switch_id == SID_ASSIGNMENT_SENDS:
+            if value == BUTTON_PRESSED:
+                self.__set_assignment_mode(CSM_SENDS)
+        elif switch_id == SID_ASSIGNMENT_PAN:
+            if value == BUTTON_PRESSED:
+                self.__set_assignment_mode(CSM_VOLPAN)
+        elif switch_id == SID_ASSIGNMENT_PLUG_INS:
+            if value == BUTTON_PRESSED:
+                self.__set_assignment_mode(CSM_PLUGINS)
+        elif switch_id == SID_ASSIGNMENT_EQ:
+            if value == BUTTON_PRESSED:
+                self.__switch_to_prev_page()
+        elif switch_id == SID_ASSIGNMENT_DYNAMIC:
+            if value == BUTTON_PRESSED:
+                self.__switch_to_next_page()
+        elif switch_id == SID_FADERBANK_PREV_BANK:
             if value == BUTTON_PRESSED:
                 if self.shift_is_pressed():
-                    self._ChannelStripController__set_channel_offset(self._ChannelStripController__controlled_num_of_tracks() - len(self._ChannelStripController__channel_strips))
-            elif self._ChannelStripController__strip_offset() < self._ChannelStripController__controlled_num_of_tracks() - len(self._ChannelStripController__channel_strips):
-                self._ChannelStripController__set_channel_offset(self._ChannelStripController__strip_offset() + 1)
-        else:
-            if switch_id == SID_FADERBANK_FLIP:
-                if value == BUTTON_PRESSED:
-                    self._ChannelStripController__toggle_flip()
-            elif switch_id == SID_FADERBANK_EDIT:
-                if value == BUTTON_PRESSED:
-                    self._ChannelStripController__toggle_view_returns()
+                    self.__set_channel_offset(0)
+                else:
+                    self.__set_channel_offset(
+                        self.__strip_offset() - len(self.__channel_strips))
+        elif switch_id == SID_FADERBANK_NEXT_BANK:
+            if value == BUTTON_PRESSED:
+                if self.shift_is_pressed():
+                    last_possible_offset = old_div(
+                        self.__controlled_num_of_tracks() - self.__strip_offset(),
+                        len(self.__channel_strips)) * len(
+                        self.__channel_strips) + self.__strip_offset()
+                    if last_possible_offset == self.__controlled_num_of_tracks():
+                        last_possible_offset -= len(self.__channel_strips)
+                    self.__set_channel_offset(last_possible_offset)
+                elif self.__strip_offset() < self.__controlled_num_of_tracks() - len(
+                    self.__channel_strips):
+                    self.__set_channel_offset(
+                        self.__strip_offset() + len(self.__channel_strips))
+        elif switch_id == SID_FADERBANK_PREV_CH:
+            if value == BUTTON_PRESSED:
+                if self.shift_is_pressed():
+                    self.__set_channel_offset(0)
+                else:
+                    self.__set_channel_offset(self.__strip_offset() - 1)
+        elif switch_id == SID_FADERBANK_NEXT_CH:
+            if value == BUTTON_PRESSED:
+                if self.shift_is_pressed():
+                    self.__set_channel_offset(
+                        self.__controlled_num_of_tracks() - len(
+                            self.__channel_strips))
+                elif self.__strip_offset() < self.__controlled_num_of_tracks() - len(
+                    self.__channel_strips):
+                    self.__set_channel_offset(self.__strip_offset() + 1)
+        elif switch_id == SID_FADERBANK_FLIP:
+            if value == BUTTON_PRESSED:
+                self.__toggle_flip()
+        elif switch_id == SID_FADERBANK_EDIT:
+            if value == BUTTON_PRESSED:
+                self.__toggle_view_returns()
 
     def handle_vpot_rotation(self, strip_index, stack_offset, cc_value):
-        if self._ChannelStripController__assignment_mode == CSM_IO:
+        pass
+        if self.__assignment_mode == CSM_IO:
             if cc_value >= 64:
                 direction = -1
             else:
                 direction = 1
-            channel_strip = self._ChannelStripController__channel_strips[stack_offset + strip_index]
-            current_routing = self._ChannelStripController__routing_target(channel_strip)
-            available_routings = self._ChannelStripController__available_routing_targets(channel_strip)
+            channel_strip = self.__channel_strips[stack_offset + strip_index]
+            current_routing = self.__routing_target(channel_strip)
+            available_routings = self.__available_routing_targets(channel_strip)
             if current_routing and available_routings:
                 if current_routing in available_routings:
                     i = list(available_routings).index(current_routing)
@@ -224,386 +225,406 @@ class ChannelStripController(MackieControlComponent):
                     else:
                         new_i = max(0, i + direction)
                     new_routing = available_routings[new_i]
-                else:
-                    if len(available_routings):
-                        new_routing = available_routings[0]
-                self._ChannelStripController__set_routing_target(channel_strip, new_routing)
-        elif self._ChannelStripController__assignment_mode == CSM_PLUGINS:
-            pass
+                elif len(available_routings):
+                    new_routing = available_routings[0]
+                self.__set_routing_target(channel_strip, new_routing)
         else:
-            channel_strip = self._ChannelStripController__channel_strips[stack_offset + strip_index]
+            if self.__assignment_mode == CSM_PLUGINS:
+                return
+            channel_strip = self.__channel_strips[stack_offset + strip_index]
 
     def handle_fader_touch(self, strip_offset, stack_offset, touched):
-        self._ChannelStripController__reassign_channel_strip_parameters(for_display_only=True)
+        pass
+        self.__reassign_channel_strip_parameters(for_display_only=True)
 
     def handle_pressed_v_pot(self, strip_index, stack_offset):
-        if not (self._ChannelStripController__assignment_mode == CSM_VOLPAN or self._ChannelStripController__assignment_mode == CSM_SENDS):
-            if not self._ChannelStripController__assignment_mode == CSM_PLUGINS or self._ChannelStripController__plugin_mode == PCM_PARAMETERS:
-                if stack_offset + strip_index in range(0, len(self._ChannelStripController__channel_strips)):
-                    param = self._ChannelStripController__channel_strips[stack_offset + strip_index].v_pot_parameter()
-                elif param:
-                    if param.is_enabled:
-                        if param.is_quantized:
-                            if param.value + 1 > param.max:
-                                param.value = param.min
-                            else:
-                                param.value = param.value + 1
-                        else:
-                            param.value = param.default_value
-        elif self._ChannelStripController__assignment_mode == CSM_PLUGINS:
-            if self._ChannelStripController__plugin_mode == PCM_DEVICES:
-                device_index = strip_index + stack_offset + self._ChannelStripController__plugin_mode_offsets[PCM_DEVICES]
-                if device_index >= 0:
-                    if device_index < len(self.song().view.selected_track.devices):
-                        if self._ChannelStripController__chosen_plugin != None:
-                            self._ChannelStripController__chosen_plugin.remove_parameters_listener(self._ChannelStripController__on_parameter_list_of_chosen_plugin_changed)
-                        self._ChannelStripController__chosen_plugin = self.song().view.selected_track.devices[device_index]
-                        if self._ChannelStripController__chosen_plugin != None:
-                            self._ChannelStripController__chosen_plugin.add_parameters_listener(self._ChannelStripController__on_parameter_list_of_chosen_plugin_changed)
-                        self._ChannelStripController__reorder_parameters()
-                        self._ChannelStripController__plugin_mode_offsets[PCM_PARAMETERS] = 0
-                        self._ChannelStripController__set_plugin_mode(PCM_PARAMETERS)
+        pass
+        if self.__assignment_mode == CSM_VOLPAN or self.__assignment_mode == CSM_SENDS or (
+            self.__assignment_mode == CSM_PLUGINS and self.__plugin_mode == PCM_PARAMETERS):
+            if stack_offset + strip_index in range(0,
+                                                   len(self.__channel_strips)):
+                param = self.__channel_strips[
+                    stack_offset + strip_index].v_pot_parameter()
+            if param and param.is_enabled:
+                if param.is_quantized:
+                    if param.value + 1 > param.max:
+                        param.value = param.min
+                    else:
+                        param.value = param.value + 1
+                else:
+                    param.value = param.default_value
+        elif self.__assignment_mode == CSM_PLUGINS:
+            if self.__plugin_mode == PCM_DEVICES:
+                device_index = strip_index + stack_offset + \
+                               self.__plugin_mode_offsets[PCM_DEVICES]
+                if device_index >= 0 and device_index < len(
+                    self.song().view.selected_track.devices):
+                    if self.__chosen_plugin != None:
+                        self.__chosen_plugin.remove_parameters_listener(
+                            self.__on_parameter_list_of_chosen_plugin_changed)
+                    self.__chosen_plugin = \
+                    self.song().view.selected_track.devices[device_index]
+                    if self.__chosen_plugin != None:
+                        self.__chosen_plugin.add_parameters_listener(
+                            self.__on_parameter_list_of_chosen_plugin_changed)
+                    self.__reorder_parameters()
+                    self.__plugin_mode_offsets[PCM_PARAMETERS] = 0
+                    self.__set_plugin_mode(PCM_PARAMETERS)
 
     def assignment_mode(self):
-        return self._ChannelStripController__assignment_mode
+        return self.__assignment_mode
 
     def __strip_offset(self):
-        if self._ChannelStripController__view_returns:
-            return self._ChannelStripController__bank_cha_offset_returns
-        return self._ChannelStripController__bank_cha_offset
+        pass
+        if self.__view_returns:
+            return self.__bank_cha_offset_returns
+        return self.__bank_cha_offset
 
     def __controlled_num_of_tracks(self):
-        if self._ChannelStripController__view_returns:
+        pass
+        if self.__view_returns:
             return len(self.song().return_tracks)
         return len(self.song().visible_tracks)
 
     def __send_parameter(self, strip_index, stack_index):
-        send_index = strip_index + stack_index + self._ChannelStripController__send_mode_offset
+        pass
+        send_index = strip_index + stack_index + self.__send_mode_offset
         if send_index < len(self.song().view.selected_track.mixer_device.sends):
             p = self.song().view.selected_track.mixer_device.sends[send_index]
             return (p, p.name)
         return (None, None)
 
-    def __plugin_parameterParse error at or near `COME_FROM' instruction at offset 82_0
+    def __plugin_parameter(self, strip_index, stack_index):
+        pass
+        if self.__plugin_mode == PCM_DEVICES:
+            return (None, None)
+        if self.__plugin_mode == PCM_PARAMETERS:
+            parameters = self.__ordered_plugin_parameters
+            parameter_index = strip_index + stack_index + \
+                              self.__plugin_mode_offsets[PCM_PARAMETERS]
+            if parameter_index >= 0 and parameter_index < len(parameters):
+                return parameters[parameter_index]
+            return (None, None)
 
     def __any_slider_is_touched(self):
-        for s in self._ChannelStripController__channel_strips:
+        for s in self.__channel_strips:
             if s.is_touched():
                 return True
-
-        return False
+        else:
+            return False
 
     def __can_flip(self):
-        if self._ChannelStripController__assignment_mode == CSM_PLUGINS:
-            if self._ChannelStripController__plugin_mode == PCM_DEVICES:
-                return False
-        if self._ChannelStripController__assignment_mode == CSM_IO:
+        if self.__assignment_mode == CSM_PLUGINS and self.__plugin_mode == PCM_DEVICES:
+            return False
+        if self.__assignment_mode == CSM_IO:
             return False
         return True
 
     def __can_switch_to_prev_page(self):
-        if self._ChannelStripController__assignment_mode == CSM_PLUGINS:
-            return self._ChannelStripController__plugin_mode_offsets[self._ChannelStripController__plugin_mode] > 0
-        if self._ChannelStripController__assignment_mode == CSM_SENDS:
-            return self._ChannelStripController__send_mode_offset > 0
+        pass
+        if self.__assignment_mode == CSM_PLUGINS:
+            return self.__plugin_mode_offsets[self.__plugin_mode] > 0
+        if self.__assignment_mode == CSM_SENDS:
+            return self.__send_mode_offset > 0
         return False
 
     def __can_switch_to_next_page(self):
-        if self._ChannelStripController__assignment_mode == CSM_PLUGINS:
+        pass
+        if self.__assignment_mode == CSM_PLUGINS:
             sel_track = self.song().view.selected_track
-            if self._ChannelStripController__plugin_mode == PCM_DEVICES:
-                return self._ChannelStripController__plugin_mode_offsets[PCM_DEVICES] + len(self._ChannelStripController__channel_strips) < len(sel_track.devices)
-            if self._ChannelStripController__plugin_mode == PCM_PARAMETERS:
-                parameters = self._ChannelStripController__ordered_plugin_parameters
-                return self._ChannelStripController__plugin_mode_offsets[PCM_PARAMETERS] + len(self._ChannelStripController__channel_strips) < len(parameters)
-        elif self._ChannelStripController__assignment_mode == CSM_SENDS:
-            return self._ChannelStripController__send_mode_offset + len(self._ChannelStripController__channel_strips) < len(self.song().return_tracks)
-        return False
+            if self.__plugin_mode == PCM_DEVICES:
+                return self.__plugin_mode_offsets[PCM_DEVICES] + len(
+                    self.__channel_strips) < len(sel_track.devices)
+            if self.__plugin_mode == PCM_PARAMETERS:
+                parameters = self.__ordered_plugin_parameters
+                return self.__plugin_mode_offsets[PCM_PARAMETERS] + len(
+                    self.__channel_strips) < len(parameters)
+        else:
+            if self.__assignment_mode == CSM_SENDS:
+                return self.__send_mode_offset + len(
+                    self.__channel_strips) < len(self.song().return_tracks)
+            return False
 
     def __available_routing_targets(self, channel_strip):
         t = channel_strip.assigned_track()
         if t:
-            if self._ChannelStripController__sub_mode_in_io_mode == CSM_IO_MODE_INPUT_MAIN:
+            if self.__sub_mode_in_io_mode == CSM_IO_MODE_INPUT_MAIN:
                 return flatten_target_list(t.available_input_routing_types)
-            if self._ChannelStripController__sub_mode_in_io_mode == CSM_IO_MODE_INPUT_SUB:
+            if self.__sub_mode_in_io_mode == CSM_IO_MODE_INPUT_SUB:
                 return flatten_target_list(t.available_input_routing_channels)
-            if self._ChannelStripController__sub_mode_in_io_mode == CSM_IO_MODE_OUTPUT_MAIN:
+            if self.__sub_mode_in_io_mode == CSM_IO_MODE_OUTPUT_MAIN:
                 return flatten_target_list(t.available_output_routing_types)
-            if self._ChannelStripController__sub_mode_in_io_mode == CSM_IO_MODE_OUTPUT_SUB:
+            if self.__sub_mode_in_io_mode == CSM_IO_MODE_OUTPUT_SUB:
                 return flatten_target_list(t.available_output_routing_channels)
         else:
-            return
+            return None
 
     def __routing_target(self, channel_strip):
         t = channel_strip.assigned_track()
         if t:
-            if self._ChannelStripController__sub_mode_in_io_mode == CSM_IO_MODE_INPUT_MAIN:
+            if self.__sub_mode_in_io_mode == CSM_IO_MODE_INPUT_MAIN:
                 return flatten_target(t.input_routing_type)
-            if self._ChannelStripController__sub_mode_in_io_mode == CSM_IO_MODE_INPUT_SUB:
+            if self.__sub_mode_in_io_mode == CSM_IO_MODE_INPUT_SUB:
                 return flatten_target(t.input_routing_channel)
-            if self._ChannelStripController__sub_mode_in_io_mode == CSM_IO_MODE_OUTPUT_MAIN:
+            if self.__sub_mode_in_io_mode == CSM_IO_MODE_OUTPUT_MAIN:
                 return flatten_target(t.output_routing_type)
-            if self._ChannelStripController__sub_mode_in_io_mode == CSM_IO_MODE_OUTPUT_SUB:
+            if self.__sub_mode_in_io_mode == CSM_IO_MODE_OUTPUT_SUB:
                 return flatten_target(t.output_routing_channel)
         else:
-            return
+            return None
 
-    def __set_routing_targetParse error at or near `COME_FROM' instruction at offset 116_4
+    def __set_routing_target(self, channel_strip, target_string):
+        t = channel_strip.assigned_track()
+        if t:
+            if self.__sub_mode_in_io_mode == CSM_IO_MODE_INPUT_MAIN:
+                t.input_routing_type = target_by_name(
+                    t.available_input_routing_types, target_string)
+            elif self.__sub_mode_in_io_mode == CSM_IO_MODE_INPUT_SUB:
+                t.input_routing_channel = target_by_name(
+                    t.available_input_routing_channels, target_string)
+            elif self.__sub_mode_in_io_mode == CSM_IO_MODE_OUTPUT_MAIN:
+                t.output_routing_type = target_by_name(
+                    t.available_output_routing_types, target_string)
+            elif self.__sub_mode_in_io_mode == CSM_IO_MODE_OUTPUT_SUB:
+                t.output_routing_channel = target_by_name(
+                    t.available_output_routing_channels, target_string)
 
     def __set_channel_offset(self, new_offset):
+        pass
         if new_offset < 0:
             new_offset = 0
+        elif new_offset >= self.__controlled_num_of_tracks():
+            new_offset = self.__controlled_num_of_tracks() - 1
+        if self.__view_returns:
+            self.__bank_cha_offset_returns = new_offset
         else:
-            if new_offset >= self._ChannelStripController__controlled_num_of_tracks():
-                new_offset = self._ChannelStripController__controlled_num_of_tracks() - 1
-            elif self._ChannelStripController__view_returns:
-                self._ChannelStripController__bank_cha_offset_returns = new_offset
-            else:
-                self._ChannelStripController__bank_cha_offset = new_offset
-            self._ChannelStripController__main_display_controller.set_channel_offset(new_offset)
-            self._ChannelStripController__reassign_channel_strip_offsets()
-            self._ChannelStripController__reassign_channel_strip_parameters(for_display_only=False)
-            self._ChannelStripController__update_channel_strip_strings()
-            self.request_rebuild_midi_map()
+            self.__bank_cha_offset = new_offset
+        self.__main_display_controller.set_channel_offset(new_offset)
+        self.__reassign_channel_strip_offsets()
+        self.__reassign_channel_strip_parameters(for_display_only=False)
+        self.__update_channel_strip_strings()
+        self.request_rebuild_midi_map()
 
     def __set_assignment_mode(self, mode):
-        for plugin in self._ChannelStripController__displayed_plugins:
+        for plugin in self.__displayed_plugins:
             if plugin != None:
-                plugin.remove_name_listener(self._ChannelStripController__update_plugin_names)
-
-        self._ChannelStripController__displayed_plugins = []
+                plugin.remove_name_listener(self.__update_plugin_names)
+        self.__displayed_plugins = []
         if mode == CSM_PLUGINS:
-            self._ChannelStripController__assignment_mode = mode
-            self._ChannelStripController__main_display_controller.set_show_parameter_names(True)
-            self._ChannelStripController__set_plugin_mode(PCM_DEVICES)
+            self.__assignment_mode = mode
+            self.__main_display_controller.set_show_parameter_names(True)
+            self.__set_plugin_mode(PCM_DEVICES)
+        elif mode == CSM_SENDS:
+            self.__main_display_controller.set_show_parameter_names(True)
+            self.__assignment_mode = mode
         else:
-            if mode == CSM_SENDS:
-                self._ChannelStripController__main_display_controller.set_show_parameter_names(True)
-                self._ChannelStripController__assignment_mode = mode
-            else:
-                if mode == CSM_IO:
-                    for s in self._ChannelStripController__channel_strips:
-                        s.unlight_vpot_leds()
-
-                else:
-                    self._ChannelStripController__main_display_controller.set_show_parameter_names(False)
-                    if self._ChannelStripController__assignment_mode != mode:
-                        self._ChannelStripController__assignment_mode = mode
-                    else:
-                        if self._ChannelStripController__assignment_mode == CSM_IO:
-                            self._ChannelStripController__switch_to_next_io_mode()
-        self._ChannelStripController__update_assignment_mode_leds()
-        self._ChannelStripController__update_assignment_display()
-        self._ChannelStripController__apply_meter_mode()
-        self._ChannelStripController__reassign_channel_strip_parameters(for_display_only=False)
-        self._ChannelStripController__update_channel_strip_strings()
-        self._ChannelStripController__update_page_switch_leds()
+            if mode == CSM_IO:
+                for s in self.__channel_strips:
+                    s.unlight_vpot_leds()
+            self.__main_display_controller.set_show_parameter_names(False)
+            if self.__assignment_mode != mode:
+                self.__assignment_mode = mode
+            elif self.__assignment_mode == CSM_IO:
+                self.__switch_to_next_io_mode()
+        self.__update_assignment_mode_leds()
+        self.__update_assignment_display()
+        self.__apply_meter_mode()
+        self.__reassign_channel_strip_parameters(for_display_only=False)
+        self.__update_channel_strip_strings()
+        self.__update_page_switch_leds()
         if mode == CSM_PLUGINS:
-            self._ChannelStripController__update_vpot_leds_in_plugins_device_choose_mode()
-        self._ChannelStripController__update_flip_led()
+            self.__update_vpot_leds_in_plugins_device_choose_mode()
+        self.__update_flip_led()
         self.request_rebuild_midi_map()
 
     def __set_plugin_mode(self, new_mode):
-        if self._ChannelStripController__plugin_mode != new_mode:
-            self._ChannelStripController__plugin_mode = new_mode
-            self._ChannelStripController__reassign_channel_strip_parameters(for_display_only=False)
+        pass
+        if self.__plugin_mode != new_mode:
+            self.__plugin_mode = new_mode
+            self.__reassign_channel_strip_parameters(for_display_only=False)
             self.request_rebuild_midi_map()
-            if self._ChannelStripController__plugin_mode == PCM_DEVICES:
-                self._ChannelStripController__update_vpot_leds_in_plugins_device_choose_mode()
+            if self.__plugin_mode == PCM_DEVICES:
+                self.__update_vpot_leds_in_plugins_device_choose_mode()
             else:
-                for plugin in self._ChannelStripController__displayed_plugins:
+                for plugin in self.__displayed_plugins:
                     if plugin != None:
-                        plugin.remove_name_listener(self._ChannelStripController__update_plugin_names)
-
-                self._ChannelStripController__displayed_plugins = []
-            self._ChannelStripController__update_page_switch_leds()
-            self._ChannelStripController__update_flip_led()
-            self._ChannelStripController__update_page_switch_leds()
+                        plugin.remove_name_listener(self.__update_plugin_names)
+                self.__displayed_plugins = []
+            self.__update_page_switch_leds()
+            self.__update_flip_led()
+            self.__update_page_switch_leds()
 
     def __switch_to_prev_page(self):
-        if self._ChannelStripController__can_switch_to_prev_page():
-            if self._ChannelStripController__assignment_mode == CSM_PLUGINS:
-                self._ChannelStripController__plugin_mode_offsets[self._ChannelStripController__plugin_mode] -= len(self._ChannelStripController__channel_strips)
-            else:
-                if self._ChannelStripController__assignment_mode == CSM_SENDS:
-                    self._ChannelStripController__send_mode_offset -= len(self._ChannelStripController__channel_strips)
-            self._ChannelStripController__reassign_channel_strip_parameters(for_display_only=False)
-            self._ChannelStripController__update_channel_strip_strings()
-            self._ChannelStripController__update_page_switch_leds()
+        pass
+        if self.__can_switch_to_prev_page():
+            if self.__assignment_mode == CSM_PLUGINS:
+                self.__plugin_mode_offsets[self.__plugin_mode] -= len(
+                    self.__channel_strips)
+            elif self.__assignment_mode == CSM_SENDS:
+                self.__send_mode_offset -= len(self.__channel_strips)
+            self.__reassign_channel_strip_parameters(for_display_only=False)
+            self.__update_channel_strip_strings()
+            self.__update_page_switch_leds()
             self.request_rebuild_midi_map()
 
     def __switch_to_next_page(self):
-        if self._ChannelStripController__can_switch_to_next_page():
-            if self._ChannelStripController__assignment_mode == CSM_PLUGINS:
-                self._ChannelStripController__plugin_mode_offsets[self._ChannelStripController__plugin_mode] += len(self._ChannelStripController__channel_strips)
-            else:
-                if self._ChannelStripController__assignment_mode == CSM_SENDS:
-                    self._ChannelStripController__send_mode_offset += len(self._ChannelStripController__channel_strips)
-                else:
-                    self._ChannelStripController__reassign_channel_strip_parameters(for_display_only=False)
-                    self._ChannelStripController__update_channel_strip_strings()
-                    self._ChannelStripController__update_page_switch_leds()
-                    self.request_rebuild_midi_map()
+        pass
+        if self.__can_switch_to_next_page():
+            if self.__assignment_mode == CSM_PLUGINS:
+                self.__plugin_mode_offsets[self.__plugin_mode] += len(
+                    self.__channel_strips)
+            elif self.__assignment_mode == CSM_SENDS:
+                self.__send_mode_offset += len(self.__channel_strips)
+            self.__reassign_channel_strip_parameters(for_display_only=False)
+            self.__update_channel_strip_strings()
+            self.__update_page_switch_leds()
+            self.request_rebuild_midi_map()
 
     def __switch_to_next_io_mode(self):
-        self._ChannelStripController__sub_mode_in_io_mode += 1
-        if self._ChannelStripController__sub_mode_in_io_mode > CSM_IO_LAST_MODE:
-            self._ChannelStripController__sub_mode_in_io_mode = CSM_IO_FIRST_MODE
+        pass
+        self.__sub_mode_in_io_mode += 1
+        if self.__sub_mode_in_io_mode > CSM_IO_LAST_MODE:
+            self.__sub_mode_in_io_mode = CSM_IO_FIRST_MODE
 
     def __reassign_channel_strip_offsets(self):
-        for s in self._ChannelStripController__channel_strips:
-            s.set_bank_and_channel_offset(self._ChannelStripController__strip_offset(), self._ChannelStripController__view_returns, self._ChannelStripController__within_track_added_or_deleted)
+        pass
+        for s in self.__channel_strips:
+            s.set_bank_and_channel_offset(self.__strip_offset(),
+                                          self.__view_returns,
+                                          self.__within_track_added_or_deleted)
 
     def __reassign_channel_strip_parameters(self, for_display_only):
+        pass
         display_parameters = []
-        for s in self._ChannelStripController__channel_strips:
+        for s in self.__channel_strips:
             vpot_param = (None, None)
             slider_param = (None, None)
             vpot_display_mode = VPOT_DISPLAY_SINGLE_DOT
             slider_display_mode = VPOT_DISPLAY_SINGLE_DOT
-            if self._ChannelStripController__assignment_mode == CSM_VOLPAN:
-                if s.assigned_track():
-                    if s.assigned_track().has_audio_output:
-                        vpot_param = (
-                         s.assigned_track().mixer_device.panning, "Pan")
-                        vpot_display_mode = VPOT_DISPLAY_BOOST_CUT
-                        slider_param = (
-                         s.assigned_track().mixer_device.volume, "Volume")
-                        slider_display_mode = VPOT_DISPLAY_WRAP
-                elif self._ChannelStripController__assignment_mode == CSM_PLUGINS:
-                    vpot_param = self._ChannelStripController__plugin_parameter(s.strip_index(), s.stack_offset())
-                    vpot_display_mode = VPOT_DISPLAY_WRAP
-                    if s.assigned_track():
-                        if s.assigned_track().has_audio_output:
-                            slider_param = (
-                             s.assigned_track().mixer_device.volume, "Volume")
-                            slider_display_mode = VPOT_DISPLAY_WRAP
-                elif self._ChannelStripController__assignment_mode == CSM_SENDS:
-                    vpot_param = self._ChannelStripController__send_parameter(s.strip_index(), s.stack_offset())
-                    vpot_display_mode = VPOT_DISPLAY_WRAP
-                    if s.assigned_track():
-                        if s.assigned_track().has_audio_output:
-                            slider_param = (
-                             s.assigned_track().mixer_device.volume, "Volume")
-                            slider_display_mode = VPOT_DISPLAY_WRAP
+            if self.__assignment_mode == CSM_VOLPAN:
+                if s.assigned_track() and s.assigned_track().has_audio_output:
+                    vpot_param = (
+                    s.assigned_track().mixer_device.panning, 'Pan')
+                    vpot_display_mode = VPOT_DISPLAY_BOOST_CUT
+                    slider_param = (
+                    s.assigned_track().mixer_device.volume, 'Volume')
+                    slider_display_mode = VPOT_DISPLAY_WRAP
+            elif self.__assignment_mode == CSM_PLUGINS:
+                vpot_param = self.__plugin_parameter(s.strip_index(),
+                                                     s.stack_offset())
+                vpot_display_mode = VPOT_DISPLAY_WRAP
+                if s.assigned_track() and s.assigned_track().has_audio_output:
+                    slider_param = (
+                    s.assigned_track().mixer_device.volume, 'Volume')
+                    slider_display_mode = VPOT_DISPLAY_WRAP
+            elif self.__assignment_mode == CSM_SENDS:
+                vpot_param = self.__send_parameter(s.strip_index(),
+                                                   s.stack_offset())
+                vpot_display_mode = VPOT_DISPLAY_WRAP
+                if s.assigned_track() and s.assigned_track().has_audio_output:
+                    slider_param = (
+                    s.assigned_track().mixer_device.volume, 'Volume')
+                    slider_display_mode = VPOT_DISPLAY_WRAP
+            elif self.__assignment_mode == CSM_IO and s.assigned_track() and s.assigned_track().has_audio_output:
+                slider_param = (
+                s.assigned_track().mixer_device.volume, 'Volume')
+            if self.__flip and self.__can_flip():
+                if self.__any_slider_is_touched():
+                    display_parameters.append(vpot_param)
                 else:
-                    if self._ChannelStripController__assignment_mode == CSM_IO:
-                        if s.assigned_track():
-                            if s.assigned_track().has_audio_output:
-                                slider_param = (
-                                 s.assigned_track().mixer_device.volume, "Volume")
-                    if self._ChannelStripController__flip and self._ChannelStripController__can_flip():
-                        if self._ChannelStripController__any_slider_is_touched():
-                            display_parameters.append(vpot_param)
-                        else:
-                            display_parameters.append(slider_param)
-                        if not for_display_only:
-                            s.set_v_pot_parameter(slider_param[0], slider_display_mode)
-                            s.set_fader_parameter(vpot_param[0])
+                    display_parameters.append(slider_param)
+                if not for_display_only:
+                    s.set_v_pot_parameter(slider_param[0], slider_display_mode)
+                    s.set_fader_parameter(vpot_param[0])
             else:
-                if self._ChannelStripController__any_slider_is_touched():
+                if self.__any_slider_is_touched():
                     display_parameters.append(slider_param)
                 else:
                     display_parameters.append(vpot_param)
-                for_display_only or s.set_v_pot_parameter(vpot_param[0], vpot_display_mode)
-                s.set_fader_parameter(slider_param[0])
-
-        self._ChannelStripController__main_display_controller.set_channel_offset(self._ChannelStripController__strip_offset())
+                if not for_display_only:
+                    s.set_v_pot_parameter(vpot_param[0], vpot_display_mode)
+                    s.set_fader_parameter(slider_param[0])
+        self.__main_display_controller.set_channel_offset(self.__strip_offset())
         if len(display_parameters):
-            self._ChannelStripController__main_display_controller.set_parameters(display_parameters)
-        if self._ChannelStripController__assignment_mode == CSM_PLUGINS:
-            if self._ChannelStripController__plugin_mode == PCM_DEVICES:
-                self._ChannelStripController__update_vpot_leds_in_plugins_device_choose_mode()
+            self.__main_display_controller.set_parameters(display_parameters)
+        if self.__assignment_mode == CSM_PLUGINS and self.__plugin_mode == PCM_DEVICES:
+            self.__update_vpot_leds_in_plugins_device_choose_mode()
 
     def _need_to_update_meter(self, meter_state_changed):
-        return meter_state_changed and self._ChannelStripController__assignment_mode == CSM_VOLPAN
+        return meter_state_changed and self.__assignment_mode == CSM_VOLPAN
 
     def __apply_meter_mode(self, meter_state_changed=False):
-        enabled = self._ChannelStripController__meters_enabled and self._ChannelStripController__assignment_mode is CSM_VOLPAN
-        send_meter_mode = self._last_assignment_mode != self._ChannelStripController__assignment_mode or self._need_to_update_meter(meter_state_changed)
-        for s in self._ChannelStripController__channel_strips:
-            s.enable_meter_mode(enabled, needs_to_send_meter_mode=send_meter_mode)
-
-        self._ChannelStripController__main_display_controller.enable_meters(enabled)
-        self._last_assignment_mode = self._ChannelStripController__assignment_mode
+        pass
+        enabled = self.__meters_enabled and self.__assignment_mode is CSM_VOLPAN
+        send_meter_mode = self._last_assignment_mode != self.__assignment_mode or self._need_to_update_meter(
+            meter_state_changed)
+        for s in self.__channel_strips:
+            s.enable_meter_mode(enabled,
+                                needs_to_send_meter_mode=send_meter_mode)
+        self.__main_display_controller.enable_meters(enabled)
+        self._last_assignment_mode = self.__assignment_mode
 
     def __toggle_flip(self):
-        if self._ChannelStripController__can_flip():
-            self._ChannelStripController__flip = not self._ChannelStripController__flip
-            self._ChannelStripController__on_flip_changed()
+        pass
+        if self.__can_flip():
+            self.__flip = not self.__flip
+            self.__on_flip_changed()
 
     def __toggle_view_returns(self):
-        self._ChannelStripController__view_returns = not self._ChannelStripController__view_returns
-        self._ChannelStripController__update_view_returns_mode()
+        pass
+        self.__view_returns = not self.__view_returns
+        self.__update_view_returns_mode()
 
     def __update_assignment_mode_leds(self):
-        if self._ChannelStripController__assignment_mode == CSM_IO:
+        pass
+        if self.__assignment_mode == CSM_IO:
             sid_on_switch = SID_ASSIGNMENT_IO
+        elif self.__assignment_mode == CSM_SENDS:
+            sid_on_switch = SID_ASSIGNMENT_SENDS
+        elif self.__assignment_mode == CSM_VOLPAN:
+            sid_on_switch = SID_ASSIGNMENT_PAN
+        elif self.__assignment_mode == CSM_PLUGINS:
+            sid_on_switch = SID_ASSIGNMENT_PLUG_INS
         else:
-            if self._ChannelStripController__assignment_mode == CSM_SENDS:
-                sid_on_switch = SID_ASSIGNMENT_SENDS
-            else:
-                if self._ChannelStripController__assignment_mode == CSM_VOLPAN:
-                    sid_on_switch = SID_ASSIGNMENT_PAN
-                else:
-                    if self._ChannelStripController__assignment_mode == CSM_PLUGINS:
-                        sid_on_switch = SID_ASSIGNMENT_PLUG_INS
-                    else:
-                        sid_on_switch = None
-        for s in (
-         SID_ASSIGNMENT_IO,
-         SID_ASSIGNMENT_SENDS,
-         SID_ASSIGNMENT_PAN,
-         SID_ASSIGNMENT_PLUG_INS):
+            sid_on_switch = None
+        for s in [SID_ASSIGNMENT_IO, SID_ASSIGNMENT_SENDS, SID_ASSIGNMENT_PAN,
+                  SID_ASSIGNMENT_PLUG_INS]:
             if s == sid_on_switch:
                 self.send_midi((NOTE_ON_STATUS, s, BUTTON_STATE_ON))
             else:
                 self.send_midi((NOTE_ON_STATUS, s, BUTTON_STATE_OFF))
 
     def __update_assignment_display(self):
-        ass_string = [
-         " ", " "]
-        if self._ChannelStripController__assignment_mode == CSM_VOLPAN:
-            ass_string = [
-             "P", "N"]
-        else:
-            if self._ChannelStripController__assignment_mode == CSM_PLUGINS or self._ChannelStripController__assignment_mode == CSM_SENDS:
-                if self._ChannelStripController__last_attached_selected_track == self.song().master_track:
-                    ass_string = [
-                     "M", "A"]
-                for t in self.song().return_tracks:
-                    if t == self._ChannelStripController__last_attached_selected_track:
-                        ass_string = ["R",
-                         chr(ord("A") + list(self.song().return_tracks).index(t))]
-                        break
-
-                for t in self.song().visible_tracks:
-                    if t == self._ChannelStripController__last_attached_selected_track:
-                        ass_string = list("%.2d" % min(99, list(self.song().visible_tracks).index(t) + 1))
-                        break
-
+        pass
+        ass_string = [' ', ' ']
+        if self.__assignment_mode == CSM_VOLPAN:
+            ass_string = ['P', 'N']
+        elif self.__assignment_mode == CSM_PLUGINS or self.__assignment_mode == CSM_SENDS:
+            if self.__last_attached_selected_track == self.song().master_track:
+                ass_string = ['M', 'A']
+            for t in self.song().return_tracks:
+                if t == self.__last_attached_selected_track:
+                    ass_string = ['R', chr(ord('A') + list(
+                        self.song().return_tracks).index(t))]
+                    break
+            for t in self.song().visible_tracks:
+                if t == self.__last_attached_selected_track:
+                    ass_string = list('%.2d' % min(99, list(
+                        self.song().visible_tracks).index(t) + 1))
+                    break
+        elif self.__assignment_mode == CSM_IO:
+            if self.__sub_mode_in_io_mode == CSM_IO_MODE_INPUT_MAIN:
+                ass_string = ['I', "'"]
+            elif self.__sub_mode_in_io_mode == CSM_IO_MODE_INPUT_SUB:
+                ass_string = ['I', ',']
+            elif self.__sub_mode_in_io_mode == CSM_IO_MODE_OUTPUT_MAIN:
+                ass_string = ['0', "'"]
+            elif self.__sub_mode_in_io_mode == CSM_IO_MODE_OUTPUT_SUB:
+                ass_string = ['0', ',']
             else:
-                if self._ChannelStripController__assignment_mode == CSM_IO:
-                    if self._ChannelStripController__sub_mode_in_io_mode == CSM_IO_MODE_INPUT_MAIN:
-                        ass_string = [
-                         "I", "'"]
-                    else:
-                        if self._ChannelStripController__sub_mode_in_io_mode == CSM_IO_MODE_INPUT_SUB:
-                            ass_string = [
-                             "I", ","]
-                        else:
-                            if self._ChannelStripController__sub_mode_in_io_mode == CSM_IO_MODE_OUTPUT_MAIN:
-                                ass_string = [
-                                 "0", "'"]
-                            else:
-                                if self._ChannelStripController__sub_mode_in_io_mode == CSM_IO_MODE_OUTPUT_SUB:
-                                    ass_string = [
-                                     "0", ","]
-                                else:
-                                    pass
-                else:
-                    self.send_midi((CC_STATUS, 75, g7_seg_led_conv_table[ass_string[0]]))
-                    self.send_midi((CC_STATUS, 74, g7_seg_led_conv_table[ass_string[1]]))
+                pass
+        self.send_midi((CC_STATUS, 75, g7_seg_led_conv_table[ass_string[0]]))
+        self.send_midi((CC_STATUS, 74, g7_seg_led_conv_table[ass_string[1]]))
 
     def __update_rude_solo_led(self):
         any_track_soloed = False
@@ -611,167 +632,203 @@ class ChannelStripController(MackieControlComponent):
             if t.solo:
                 any_track_soloed = True
                 break
-
         if any_track_soloed:
             self.send_midi((NOTE_ON_STATUS, SELECT_RUDE_SOLO, BUTTON_STATE_ON))
         else:
             self.send_midi((NOTE_ON_STATUS, SELECT_RUDE_SOLO, BUTTON_STATE_OFF))
 
     def __update_page_switch_leds(self):
-        if self._ChannelStripController__can_switch_to_prev_page():
+        pass
+        if self.__can_switch_to_prev_page():
             self.send_midi((NOTE_ON_STATUS, SID_ASSIGNMENT_EQ, BUTTON_STATE_ON))
         else:
-            self.send_midi((NOTE_ON_STATUS, SID_ASSIGNMENT_EQ, BUTTON_STATE_OFF))
-        if self._ChannelStripController__can_switch_to_next_page():
-            self.send_midi((NOTE_ON_STATUS, SID_ASSIGNMENT_DYNAMIC, BUTTON_STATE_ON))
+            self.send_midi(
+                (NOTE_ON_STATUS, SID_ASSIGNMENT_EQ, BUTTON_STATE_OFF))
+        if self.__can_switch_to_next_page():
+            self.send_midi(
+                (NOTE_ON_STATUS, SID_ASSIGNMENT_DYNAMIC, BUTTON_STATE_ON))
         else:
-            self.send_midi((NOTE_ON_STATUS, SID_ASSIGNMENT_DYNAMIC, BUTTON_STATE_OFF))
+            self.send_midi(
+                (NOTE_ON_STATUS, SID_ASSIGNMENT_DYNAMIC, BUTTON_STATE_OFF))
 
     def __update_flip_led(self):
-        if self._ChannelStripController__flip and self._ChannelStripController__can_flip():
-            self.send_midi((NOTE_ON_STATUS, SID_FADERBANK_FLIP, BUTTON_STATE_ON))
+        if self.__flip and self.__can_flip():
+            self.send_midi(
+                (NOTE_ON_STATUS, SID_FADERBANK_FLIP, BUTTON_STATE_ON))
         else:
-            self.send_midi((NOTE_ON_STATUS, SID_FADERBANK_FLIP, BUTTON_STATE_OFF))
+            self.send_midi(
+                (NOTE_ON_STATUS, SID_FADERBANK_FLIP, BUTTON_STATE_OFF))
 
     def __update_vpot_leds_in_plugins_device_choose_mode(self):
+        pass
         sel_track = self.song().view.selected_track
         count = 0
-        for s in self._ChannelStripController__channel_strips:
-            offset = self._ChannelStripController__plugin_mode_offsets[self._ChannelStripController__plugin_mode]
-            if sel_track and offset + count >= 0 and offset + count < len(sel_track.devices):
+        for s in self.__channel_strips:
+            offset = self.__plugin_mode_offsets[self.__plugin_mode]
+            if sel_track and offset + count >= 0 and (
+                offset + count < len(sel_track.devices)):
                 s.show_full_enlighted_poti()
             else:
                 s.unlight_vpot_leds()
             count += 1
 
     def __update_channel_strip_strings(self):
-        if (self._ChannelStripController__any_slider_is_touched() or self._ChannelStripController__assignment_mode) == CSM_IO:
-            targets = []
-            for s in self._ChannelStripController__channel_strips:
-                if self._ChannelStripController__routing_target(s):
-                    targets.append(self._ChannelStripController__routing_target(s))
-                else:
-                    targets.append("")
-
-            self._ChannelStripController__main_display_controller.set_channel_strip_strings(targets)
-        else:
-            if self._ChannelStripController__assignment_mode == CSM_PLUGINS:
-                if self._ChannelStripController__plugin_mode == PCM_DEVICES:
-                    for plugin in self._ChannelStripController__displayed_plugins:
-                        if plugin != None:
-                            plugin.remove_name_listener(self._ChannelStripController__update_plugin_names)
-
-                    self._ChannelStripController__displayed_plugins = []
-                    sel_track = self.song().view.selected_track
-                    for i in range(len(self._ChannelStripController__channel_strips)):
-                        device_index = i + self._ChannelStripController__plugin_mode_offsets[PCM_DEVICES]
-                        if device_index >= 0 and device_index < len(sel_track.devices):
-                            sel_track.devices[device_index].add_name_listener(self._ChannelStripController__update_plugin_names)
-                            self._ChannelStripController__displayed_plugins.append(sel_track.devices[device_index])
-                        else:
-                            self._ChannelStripController__displayed_plugins.append(None)
-
-                    self._ChannelStripController__update_plugin_names()
+        pass
+        if not self.__any_slider_is_touched():
+            if self.__assignment_mode == CSM_IO:
+                targets = []
+                for s in self.__channel_strips:
+                    if self.__routing_target(s):
+                        targets.append(self.__routing_target(s))
+                    else:
+                        targets.append('')
+                self.__main_display_controller.set_channel_strip_strings(
+                    targets)
+            elif self.__assignment_mode == CSM_PLUGINS and self.__plugin_mode == PCM_DEVICES:
+                for plugin in self.__displayed_plugins:
+                    if plugin != None:
+                        plugin.remove_name_listener(self.__update_plugin_names)
+                self.__displayed_plugins = []
+                sel_track = self.song().view.selected_track
+                for i in range(len(self.__channel_strips)):
+                    device_index = i + self.__plugin_mode_offsets[PCM_DEVICES]
+                    if device_index >= 0 and device_index < len(
+                        sel_track.devices):
+                        sel_track.devices[device_index].add_name_listener(
+                            self.__update_plugin_names)
+                        self.__displayed_plugins.append(
+                            sel_track.devices[device_index])
+                    else:
+                        self.__displayed_plugins.append(None)
+                self.__update_plugin_names()
 
     def __update_plugin_names(self):
         device_strings = []
-        for plugin in self._ChannelStripController__displayed_plugins:
+        for plugin in self.__displayed_plugins:
             if plugin != None:
                 device_strings.append(plugin.name)
             else:
-                device_strings.append("")
-
-        self._ChannelStripController__main_display_controller.set_channel_strip_strings(device_strings)
+                device_strings.append('')
+        self.__main_display_controller.set_channel_strip_strings(device_strings)
 
     def __update_view_returns_mode(self):
-        if self._ChannelStripController__view_returns:
-            self.send_midi((NOTE_ON_STATUS, SID_FADERBANK_EDIT, BUTTON_STATE_ON))
+        pass
+        if self.__view_returns:
+            self.send_midi(
+                (NOTE_ON_STATUS, SID_FADERBANK_EDIT, BUTTON_STATE_ON))
         else:
-            self.send_midi((NOTE_ON_STATUS, SID_FADERBANK_EDIT, BUTTON_STATE_OFF))
-        self._ChannelStripController__main_display_controller.set_show_return_track_names(self._ChannelStripController__view_returns)
-        self._ChannelStripController__reassign_channel_strip_offsets()
-        self._ChannelStripController__reassign_channel_strip_parameters(for_display_only=False)
+            self.send_midi(
+                (NOTE_ON_STATUS, SID_FADERBANK_EDIT, BUTTON_STATE_OFF))
+        self.__main_display_controller.set_show_return_track_names(
+            self.__view_returns)
+        self.__reassign_channel_strip_offsets()
+        self.__reassign_channel_strip_parameters(for_display_only=False)
         self.request_rebuild_midi_map()
 
     def __on_selected_track_changed(self):
-        st = self._ChannelStripController__last_attached_selected_track
+        pass
+        st = self.__last_attached_selected_track
+        if st and st.devices_has_listener(
+            self.__on_selected_device_chain_changed):
+            st.remove_devices_listener(self.__on_selected_device_chain_changed)
+        self.__last_attached_selected_track = self.song().view.selected_track
+        st = self.__last_attached_selected_track
         if st:
-            if st.devices_has_listener(self._ChannelStripController__on_selected_device_chain_changed):
-                st.remove_devices_listener(self._ChannelStripController__on_selected_device_chain_changed)
-        else:
-            self._ChannelStripController__last_attached_selected_track = self.song().view.selected_track
-            st = self._ChannelStripController__last_attached_selected_track
-            if st:
-                st.add_devices_listener(self._ChannelStripController__on_selected_device_chain_changed)
-            if self._ChannelStripController__assignment_mode == CSM_PLUGINS:
-                self._ChannelStripController__plugin_mode_offsets = [0 for x in range(PCM_NUMMODES)]
-                if self._ChannelStripController__chosen_plugin != None:
-                    self._ChannelStripController__chosen_plugin.remove_parameters_listener(self._ChannelStripController__on_parameter_list_of_chosen_plugin_changed)
-                self._ChannelStripController__chosen_plugin = None
-                self._ChannelStripController__ordered_plugin_parameters = []
-                self._ChannelStripController__update_assignment_display()
-                if self._ChannelStripController__plugin_mode == PCM_DEVICES:
-                    self._ChannelStripController__update_vpot_leds_in_plugins_device_choose_mode()
-                else:
-                    self._ChannelStripController__set_plugin_mode(PCM_DEVICES)
-            elif self._ChannelStripController__assignment_mode == CSM_SENDS:
-                self._ChannelStripController__reassign_channel_strip_parameters(for_display_only=False)
-                self._ChannelStripController__update_assignment_display()
-                self.request_rebuild_midi_map()
+            st.add_devices_listener(self.__on_selected_device_chain_changed)
+        if self.__assignment_mode == CSM_PLUGINS:
+            self.__plugin_mode_offsets = [0 for x in range(PCM_NUMMODES)]
+            if self.__chosen_plugin != None:
+                self.__chosen_plugin.remove_parameters_listener(
+                    self.__on_parameter_list_of_chosen_plugin_changed)
+            self.__chosen_plugin = None
+            self.__ordered_plugin_parameters = []
+            self.__update_assignment_display()
+            if self.__plugin_mode == PCM_DEVICES:
+                self.__update_vpot_leds_in_plugins_device_choose_mode()
+            else:
+                self.__set_plugin_mode(PCM_DEVICES)
+        elif self.__assignment_mode == CSM_SENDS:
+            self.__reassign_channel_strip_parameters(for_display_only=False)
+            self.__update_assignment_display()
+            self.request_rebuild_midi_map()
 
     def __on_flip_changed(self):
-        self._ChannelStripController__update_flip_led()
-        if self._ChannelStripController__can_flip():
-            self._ChannelStripController__update_assignment_display()
-            self._ChannelStripController__reassign_channel_strip_parameters(for_display_only=False)
+        pass
+        self.__update_flip_led()
+        if self.__can_flip():
+            self.__update_assignment_display()
+            self.__reassign_channel_strip_parameters(for_display_only=False)
             self.request_rebuild_midi_map()
 
     def __on_selected_device_chain_changed(self):
-        if self._ChannelStripController__assignment_mode == CSM_PLUGINS:
-            if self._ChannelStripController__plugin_mode == PCM_DEVICES:
-                self._ChannelStripController__update_vpot_leds_in_plugins_device_choose_mode()
-                self._ChannelStripController__update_page_switch_leds()
-            else:
-                if self._ChannelStripController__plugin_mode == PCM_PARAMETERS:
-                    if not self._ChannelStripController__chosen_plugin:
-                        self._ChannelStripController__set_plugin_mode(PCM_DEVICES)
-                    else:
-                        if self._ChannelStripController__chosen_plugin not in self._ChannelStripController__last_attached_selected_track.devices:
-                            if self._ChannelStripController__chosen_plugin != None:
-                                self._ChannelStripController__chosen_plugin.remove_parameters_listener(self._ChannelStripController__on_parameter_list_of_chosen_plugin_changed)
-                            self._ChannelStripController__chosen_plugin = None
-                            self._ChannelStripController__set_plugin_mode(PCM_DEVICES)
+        if self.__assignment_mode == CSM_PLUGINS:
+            if self.__plugin_mode == PCM_DEVICES:
+                self.__update_vpot_leds_in_plugins_device_choose_mode()
+                self.__update_page_switch_leds()
+            elif self.__plugin_mode == PCM_PARAMETERS:
+                if not self.__chosen_plugin:
+                    self.__set_plugin_mode(PCM_DEVICES)
+                elif self.__chosen_plugin not in self.__last_attached_selected_track.devices:
+                    if self.__chosen_plugin != None:
+                        self.__chosen_plugin.remove_parameters_listener(
+                            self.__on_parameter_list_of_chosen_plugin_changed)
+                    self.__chosen_plugin = None
+                    self.__set_plugin_mode(PCM_DEVICES)
 
     def __on_tracks_added_or_deleted(self):
-        self._ChannelStripController__within_track_added_or_deleted = True
+        pass
+        self.__within_track_added_or_deleted = True
         for t in chain(self.song().visible_tracks, self.song().return_tracks):
-            if not t.solo_has_listener(self._ChannelStripController__update_rude_solo_led):
-                t.add_solo_listener(self._ChannelStripController__update_rude_solo_led)
-            if not t.has_audio_output_has_listener(self._ChannelStripController__on_any_tracks_output_type_changed):
-                t.add_has_audio_output_listener(self._ChannelStripController__on_any_tracks_output_type_changed)
-
-        if self._ChannelStripController__send_mode_offset >= len(self.song().return_tracks):
-            self._ChannelStripController__send_mode_offset = 0
-            self._ChannelStripController__reassign_channel_strip_parameters(for_display_only=False)
-            self._ChannelStripController__update_channel_strip_strings()
-        if self._ChannelStripController__strip_offset() + len(self._ChannelStripController__channel_strips) >= self._ChannelStripController__controlled_num_of_tracks():
-            self._ChannelStripController__set_channel_offset(max(0, self._ChannelStripController__controlled_num_of_tracks() - len(self._ChannelStripController__channel_strips)))
-        self._ChannelStripController__reassign_channel_strip_parameters(for_display_only=False)
-        self._ChannelStripController__update_channel_strip_strings()
-        if self._ChannelStripController__assignment_mode == CSM_SENDS:
-            self._ChannelStripController__update_page_switch_leds()
+            if not t.solo_has_listener(self.__update_rude_solo_led):
+                t.add_solo_listener(self.__update_rude_solo_led)
+            if not t.has_audio_output_has_listener(
+                self.__on_any_tracks_output_type_changed):
+                t.add_has_audio_output_listener(
+                    self.__on_any_tracks_output_type_changed)
+        if self.__send_mode_offset >= len(self.song().return_tracks):
+            self.__send_mode_offset = 0
+            self.__reassign_channel_strip_parameters(for_display_only=False)
+            self.__update_channel_strip_strings()
+        if self.__strip_offset() + len(
+            self.__channel_strips) >= self.__controlled_num_of_tracks():
+            self.__set_channel_offset(max(0,
+                                          self.__controlled_num_of_tracks() - len(
+                                              self.__channel_strips)))
+        self.__reassign_channel_strip_parameters(for_display_only=False)
+        self.__update_channel_strip_strings()
+        if self.__assignment_mode == CSM_SENDS:
+            self.__update_page_switch_leds()
         self.refresh_state()
-        self._ChannelStripController__main_display_controller.refresh_state()
-        self._ChannelStripController__within_track_added_or_deleted = False
+        self.__main_display_controller.refresh_state()
+        self.__within_track_added_or_deleted = False
         self.request_rebuild_midi_map()
 
     def __on_any_tracks_output_type_changed(self):
-        self._ChannelStripController__reassign_channel_strip_parameters(for_display_only=False)
+        pass
+        self.__reassign_channel_strip_parameters(for_display_only=False)
         self.request_rebuild_midi_map()
 
     def __on_parameter_list_of_chosen_plugin_changed(self):
-        self._ChannelStripController__reorder_parameters()
-        self._ChannelStripController__reassign_channel_strip_parameters(for_display_only=False)
+        self.__reorder_parameters()
+        self.__reassign_channel_strip_parameters(for_display_only=False)
         self.request_rebuild_midi_map()
 
-    def __reorder_parametersParse error at or near `COME_FROM_LOOP' instruction at offset 138_0
+    def __reorder_parameters(self):
+        result = []
+        if self.__chosen_plugin:
+            if self.__chosen_plugin.class_name in list(DEVICE_DICT.keys()):
+                device_banks = DEVICE_DICT[self.__chosen_plugin.class_name]
+                for bank in device_banks:
+                    for param_name in bank:
+                        parameter_name = ''
+                        parameter = get_parameter_by_name(self.__chosen_plugin,
+                                                          param_name)
+                        if parameter:
+                            parameter_name = parameter.name
+                        result.append((parameter, parameter_name))
+            else:
+                result = [(p, p.name) for p in
+                          self.__chosen_plugin.parameters[1:]]
+        else:
+            pass
+        self.__ordered_plugin_parameters = result

--- a/MackieControl/MackieControl.py
+++ b/MackieControl/MackieControl.py
@@ -1,89 +1,103 @@
-# uncompyle6 version 3.9.1
-# Python bytecode version base 3.7.0 (3394)
-# Decompiled from: Python 3.12.2 (main, Feb  6 2024, 20:19:44) [Clang 15.0.0 (clang-1500.1.0.2.5)]
-# Embedded file name: output/Live/mac_universal_64_static/Release/python-bundle/MIDI Remote Scripts/MackieControl/MackieControl.py
-# Compiled at: 2024-03-09 01:30:22
-# Size of source mod 2**32: 13640 bytes
-from __future__ import absolute_import, print_function, unicode_literals
-from builtins import object, range
-import Live, MidiRemoteScript
+# Decompiled with PyLingual (https://pylingual.io)
+# Internal filename: ..\..\..\output\Live\win_64_static\Release\python-bundle\MIDI Remote Scripts\MackieControl\MackieControl.py
+# Bytecode version: 3.11a7e (3495)
+# Source timestamp: 2024-09-26 15:27:47 UTC (1727364467)
+
+import Live
+
 from .ChannelStrip import ChannelStrip, MasterChannelStrip
 from .ChannelStripController import ChannelStripController
-from .consts import *
 from .MainDisplay import MainDisplay
 from .MainDisplayController import MainDisplayController
 from .SoftwareController import SoftwareController
 from .TimeDisplay import TimeDisplay
 from .Transport import Transport
+from .consts import *
+
 
 class MackieControl(object):
+    pass
 
     def __init__(self, c_instance):
-        self._MackieControl__c_instance = c_instance
-        self._MackieControl__components = []
-        self._MackieControl__main_display = MainDisplay(self)
-        self._MackieControl__components.append(self._MackieControl__main_display)
-        self._MackieControl__main_display_controller = MainDisplayController(self, self._MackieControl__main_display)
-        self._MackieControl__components.append(self._MackieControl__main_display_controller)
-        self._MackieControl__time_display = TimeDisplay(self)
-        self._MackieControl__components.append(self._MackieControl__time_display)
-        self._MackieControl__software_controller = SoftwareController(self)
-        self._MackieControl__components.append(self._MackieControl__software_controller)
-        self._MackieControl__transport = Transport(self)
-        self._MackieControl__components.append(self._MackieControl__transport)
-        self._MackieControl__channel_strips = [ChannelStrip(self, i) for i in range(NUM_CHANNEL_STRIPS)]
-        for s in self._MackieControl__channel_strips:
-            self._MackieControl__components.append(s)
-
-        self._MackieControl__master_strip = MasterChannelStrip(self)
-        self._MackieControl__components.append(self._MackieControl__master_strip)
-        self._MackieControl__channel_strip_controller = ChannelStripController(self, self._MackieControl__channel_strips, self._MackieControl__master_strip, self._MackieControl__main_display_controller)
-        self._MackieControl__components.append(self._MackieControl__channel_strip_controller)
-        self._MackieControl__shift_is_pressed = False
-        self._MackieControl__option_is_pressed = False
-        self._MackieControl__ctrl_is_pressed = False
-        self._MackieControl__alt_is_pressed = False
+        self.__c_instance = c_instance
+        self.__components = []
+        self.__main_display = MainDisplay(self)
+        self.__components.append(self.__main_display)
+        self.__main_display_controller = MainDisplayController(self,
+                                                               self.__main_display)
+        self.__components.append(self.__main_display_controller)
+        self.__time_display = TimeDisplay(self)
+        self.__components.append(self.__time_display)
+        self.__software_controller = SoftwareController(self)
+        self.__components.append(self.__software_controller)
+        self.__transport = Transport(self)
+        self.__components.append(self.__transport)
+        self.__channel_strips = [ChannelStrip(self, i) for i in
+                                 range(NUM_CHANNEL_STRIPS)]
+        for s in self.__channel_strips:
+            self.__components.append(s)
+        self.__master_strip = MasterChannelStrip(self)
+        self.__components.append(self.__master_strip)
+        self.__channel_strip_controller = ChannelStripController(self,
+                                                                 self.__channel_strips,
+                                                                 self.__master_strip,
+                                                                 self.__main_display_controller)
+        self.__components.append(self.__channel_strip_controller)
+        self.__shift_is_pressed = False
+        self.__option_is_pressed = False
+        self.__ctrl_is_pressed = False
+        self.__alt_is_pressed = False
         self.is_pro_version = False
         self._received_firmware_version = False
         self._refresh_state_next_time = 0
 
     def disconnect(self):
-        for c in self._MackieControl__components:
+        for c in self.__components:
             c.destroy()
 
     def connect_script_instances(self, instanciated_scripts):
+        pass
         try:
-            import MackieControlXT.MackieControlXT as MackieControlXT
+            from MackieControlXT.MackieControlXT import MackieControlXT
         except:
-            print("failed to load the MackieControl XT script (might not be installed)")
-
+            print(
+                'failed to load the MackieControl XT script (might not be installed)')
         found_self = False
         right_extensions = []
         left_extensions = []
         for s in instanciated_scripts:
             if s is self:
                 found_self = True
-
-        self._MackieControl__main_display_controller.set_controller_extensions(left_extensions, right_extensions)
-        self._MackieControl__channel_strip_controller.set_controller_extensions(left_extensions, right_extensions)
+            elif isinstance(s, MackieControlXT):
+                s.set_mackie_control_main(self)
+                if found_self:
+                    right_extensions.append(s)
+                else:
+                    left_extensions.append(s)
+        self.__main_display_controller.set_controller_extensions(
+            left_extensions, right_extensions)
+        self.__channel_strip_controller.set_controller_extensions(
+            left_extensions, right_extensions)
 
     def request_firmware_version(self):
         if not self._received_firmware_version:
             self.send_midi((240, 0, 0, 102, SYSEX_DEVICE_TYPE, 19, 0, 247))
 
     def application(self):
+        pass
         return Live.Application.get_application()
 
     def song(self):
-        return self._MackieControl__c_instance.song()
+        pass
+        return self.__c_instance.song()
 
     def handle(self):
-        return self._MackieControl__c_instance.handle()
+        pass
+        return self.__c_instance.handle()
 
     def refresh_state(self):
-        for c in self._MackieControl__components:
+        for c in self.__components:
             c.refresh_state()
-
         self.request_firmware_version()
         self._refresh_state_next_time = 30
 
@@ -91,117 +105,121 @@ class MackieControl(object):
         return False
 
     def request_rebuild_midi_map(self):
-        self._MackieControl__c_instance.request_rebuild_midi_map()
+        pass
+        self.__c_instance.request_rebuild_midi_map()
 
     def build_midi_map(self, midi_map_handle):
-        for s in self._MackieControl__channel_strips:
+        pass
+        for s in self.__channel_strips:
             s.build_midi_map(midi_map_handle)
-
-        self._MackieControl__master_strip.build_midi_map(midi_map_handle)
+        self.__master_strip.build_midi_map(midi_map_handle)
         for i in range(SID_FIRST, SID_LAST + 1):
             if i not in function_key_control_switch_ids:
-                Live.MidiMap.forward_midi_note(self.handle(), midi_map_handle, 0, i)
-
-        Live.MidiMap.forward_midi_cc(self.handle(), midi_map_handle, 0, JOG_WHEEL_CC_NO)
+                Live.MidiMap.forward_midi_note(self.handle(), midi_map_handle,
+                                               0, i)
+        Live.MidiMap.forward_midi_cc(self.handle(), midi_map_handle, 0,
+                                     JOG_WHEEL_CC_NO)
 
     def update_display(self):
         if self._refresh_state_next_time > 0:
             self._refresh_state_next_time -= 1
             if self._refresh_state_next_time == 0:
-                for c in self._MackieControl__components:
+                for c in self.__components:
                     c.refresh_state()
-
                 self.request_firmware_version()
-        for c in self._MackieControl__components:
+        for c in self.__components:
             c.on_update_display_timer()
 
     def send_midi(self, midi_event_bytes):
-        self._MackieControl__c_instance.send_midi(midi_event_bytes)
+        pass
+        self.__c_instance.send_midi(midi_event_bytes)
 
     def receive_midi(self, midi_bytes):
-        if midi_bytes[0] & 240 == NOTE_ON_STATUS or midi_bytes[0] & 240 == NOTE_OFF_STATUS:
+        if midi_bytes[0] & 240 == NOTE_ON_STATUS or midi_bytes[
+            0] & 240 == NOTE_OFF_STATUS:
             note = midi_bytes[1]
             value = BUTTON_PRESSED if midi_bytes[2] > 0 else BUTTON_RELEASED
             if note in range(SID_FIRST, SID_LAST + 1):
                 if note in display_switch_ids:
-                    self._MackieControl__handle_display_switch_ids(note, value)
+                    self.__handle_display_switch_ids(note, value)
                 if note in channel_strip_switch_ids + fader_touch_switch_ids:
-                    for s in self._MackieControl__channel_strips:
+                    for s in self.__channel_strips:
                         s.handle_channel_strip_switch_ids(note, value)
-
                 if note in channel_strip_control_switch_ids:
-                    self._MackieControl__channel_strip_controller.handle_assignment_switch_ids(note, value)
+                    self.__channel_strip_controller.handle_assignment_switch_ids(
+                        note, value)
                 if note in function_key_control_switch_ids:
-                    self._MackieControl__software_controller.handle_function_key_switch_ids(note, value)
+                    self.__software_controller.handle_function_key_switch_ids(
+                        note, value)
                 if note in software_controls_switch_ids:
-                    self._MackieControl__software_controller.handle_software_controls_switch_ids(note, value)
+                    self.__software_controller.handle_software_controls_switch_ids(
+                        note, value)
                 if note in transport_control_switch_ids:
-                    self._MackieControl__transport.handle_transport_switch_ids(note, value)
+                    self.__transport.handle_transport_switch_ids(note, value)
                 if note in marker_control_switch_ids:
-                    self._MackieControl__transport.handle_marker_switch_ids(note, value)
+                    self.__transport.handle_marker_switch_ids(note, value)
                 if note in jog_wheel_switch_ids:
-                    self._MackieControl__transport.handle_jog_wheel_switch_ids(note, value)
-            elif midi_bytes[0] & 240 == CC_STATUS:
-                cc_no = midi_bytes[1]
-                cc_value = midi_bytes[2]
-                if cc_no == JOG_WHEEL_CC_NO:
-                    self._MackieControl__transport.handle_jog_wheel_rotation(cc_value)
-            elif cc_no in range(FID_PANNING_BASE, FID_PANNING_BASE + NUM_CHANNEL_STRIPS):
-                for s in self._MackieControl__channel_strips:
+                    self.__transport.handle_jog_wheel_switch_ids(note, value)
+        elif midi_bytes[0] & 240 == CC_STATUS:
+            cc_no = midi_bytes[1]
+            cc_value = midi_bytes[2]
+            if cc_no == JOG_WHEEL_CC_NO:
+                self.__transport.handle_jog_wheel_rotation(cc_value)
+            elif cc_no in range(FID_PANNING_BASE,
+                                FID_PANNING_BASE + NUM_CHANNEL_STRIPS):
+                for s in self.__channel_strips:
                     s.handle_vpot_rotation(cc_no - FID_PANNING_BASE, cc_value)
-
-        else:
-            if midi_bytes[0] == 240:
-                if len(midi_bytes) == 12:
-                    if midi_bytes[5] == 20:
-                        version_bytes = midi_bytes[6[:-2]]
-                        major_version = version_bytes[1]
-                        self.is_pro_version = major_version > 50
-                        self._received_firmware_version = True
+        elif midi_bytes[0] == 240 and len(midi_bytes) == 12 and (
+            midi_bytes[5] == 20):
+            version_bytes = midi_bytes[6:-2]
+            major_version = version_bytes[1]
+            self.is_pro_version = major_version > 50
+            self._received_firmware_version = True
 
     def can_lock_to_devices(self):
         return False
 
     def suggest_input_port(self):
-        return ""
+        return ''
 
     def suggest_output_port(self):
-        return ""
+        return ''
 
     def suggest_map_mode(self, cc_no, channel):
         result = Live.MidiMap.MapMode.absolute
-        if cc_no in range(FID_PANNING_BASE, FID_PANNING_BASE + NUM_CHANNEL_STRIPS):
+        if cc_no in range(FID_PANNING_BASE,
+                          FID_PANNING_BASE + NUM_CHANNEL_STRIPS):
             result = Live.MidiMap.MapMode.relative_signed_bit
         return result
 
     def shift_is_pressed(self):
-        return self._MackieControl__shift_is_pressed
+        return self.__shift_is_pressed
 
     def set_shift_is_pressed(self, pressed):
-        self._MackieControl__shift_is_pressed = pressed
+        self.__shift_is_pressed = pressed
 
     def option_is_pressed(self):
-        return self._MackieControl__option_is_pressed
+        return self.__option_is_pressed
 
     def set_option_is_pressed(self, pressed):
-        self._MackieControl__option_is_pressed = pressed
+        self.__option_is_pressed = pressed
 
     def control_is_pressed(self):
-        return self._MackieControl__control_is_pressed
+        return self.__control_is_pressed
 
     def set_control_is_pressed(self, pressed):
-        self._MackieControl__control_is_pressed = pressed
+        self.__control_is_pressed = pressed
 
     def alt_is_pressed(self):
-        return self._MackieControl__alt_is_pressed
+        return self.__alt_is_pressed
 
     def set_alt_is_pressed(self, pressed):
-        self._MackieControl__alt_is_pressed = pressed
+        self.__alt_is_pressed = pressed
 
     def __handle_display_switch_ids(self, switch_id, value):
         if switch_id == SID_DISPLAY_NAME_VALUE:
             if value == BUTTON_PRESSED:
-                self._MackieControl__channel_strip_controller.toggle_meter_mode()
+                self.__channel_strip_controller.toggle_meter_mode()
         elif switch_id == SID_DISPLAY_SMPTE_BEATS:
             if value == BUTTON_PRESSED:
-                self._MackieControl__time_display.toggle_mode()
+                self.__time_display.toggle_mode()

--- a/MackieControl/MackieControlComponent.py
+++ b/MackieControl/MackieControlComponent.py
@@ -1,48 +1,43 @@
-# uncompyle6 version 3.9.1
-# Python bytecode version base 3.7.0 (3394)
-# Decompiled from: Python 3.12.2 (main, Feb  6 2024, 20:19:44) [Clang 15.0.0 (clang-1500.1.0.2.5)]
-# Embedded file name: output/Live/mac_universal_64_static/Release/python-bundle/MIDI Remote Scripts/MackieControl/MackieControlComponent.py
-# Compiled at: 2024-03-09 01:30:22
-# Size of source mod 2**32: 2500 bytes
+# Decompiled with PyLingual (https://pylingual.io)
+# Internal filename: ..\..\..\output\Live\win_64_static\Release\python-bundle\MIDI Remote Scripts\MackieControl\MackieControlComponent.py
+# Bytecode version: 3.11a7e (3495)
+# Source timestamp: 2024-09-26 15:27:47 UTC (1727364467)
 from __future__ import absolute_import, print_function, unicode_literals
-from builtins import object
-import Live
 from .consts import *
 
 class MackieControlComponent(object):
-
     def __init__(self, main_script):
-        self._MackieControlComponent__main_script = main_script
+        self.__main_script = main_script
 
     def destroy(self):
-        self._MackieControlComponent__main_script = None
+        self.__main_script = None
 
     def main_script(self):
-        return self._MackieControlComponent__main_script
+        return self.__main_script
 
     def shift_is_pressed(self):
-        return self._MackieControlComponent__main_script.shift_is_pressed()
+        return self.__main_script.shift_is_pressed()
 
     def option_is_pressed(self):
-        return self._MackieControlComponent__main_script.option_is_pressed()
+        return self.__main_script.option_is_pressed()
 
     def control_is_pressed(self):
-        return self._MackieControlComponent__main_script.control_is_pressed()
+        return self.__main_script.control_is_pressed()
 
     def alt_is_pressed(self):
-        return self._MackieControlComponent__main_script.alt_is_pressed()
+        return self.__main_script.alt_is_pressed()
 
     def song(self):
-        return self._MackieControlComponent__main_script.song()
+        return self.__main_script.song()
 
     def script_handle(self):
-        return self._MackieControlComponent__main_script.handle()
+        return self.__main_script.handle()
 
     def application(self):
-        return self._MackieControlComponent__main_script.application()
+        return self.__main_script.application()
 
     def send_midi(self, bytes):
-        self._MackieControlComponent__main_script.send_midi(bytes)
+        self.__main_script.send_midi(bytes)
 
     def request_rebuild_midi_map(self):
-        self._MackieControlComponent__main_script.request_rebuild_midi_map()
+        self.__main_script.request_rebuild_midi_map()

--- a/MackieControl/MainDisplay.py
+++ b/MackieControl/MainDisplay.py
@@ -1,54 +1,50 @@
-# uncompyle6 version 3.9.1
-# Python bytecode version base 3.7.0 (3394)
-# Decompiled from: Python 3.12.2 (main, Feb  6 2024, 20:19:44) [Clang 15.0.0 (clang-1500.1.0.2.5)]
-# Embedded file name: output/Live/mac_universal_64_static/Release/python-bundle/MIDI Remote Scripts/MackieControl/MainDisplay.py
-# Compiled at: 2024-03-09 01:30:22
-# Size of source mod 2**32: 3343 bytes
-from __future__ import absolute_import, print_function, unicode_literals
+# Decompiled with PyLingual (https://pylingual.io)
+# Internal filename: ..\..\..\output\Live\win_64_static\Release\python-bundle\MIDI Remote Scripts\MackieControl\MainDisplay.py
+# Bytecode version: 3.11a7e (3495)
+# Source timestamp: 2024-09-26 15:27:47 UTC (1727364467)
 from ableton.v3.base import as_ascii
 from .MackieControlComponent import *
 
 class MainDisplay(MackieControlComponent):
+    pass
 
     def __init__(self, main_script):
         MackieControlComponent.__init__(self, main_script)
-        self._MainDisplay__stack_offset = 0
-        self._MainDisplay__last_send_messages = [[], []]
+        self.__stack_offset = 0
+        self.__last_send_messages = [[], []]
 
     def destroy(self):
         NUM_CHARS_PER_DISPLAY_LINE = 54
-        upper_message = "Ableton Live".center(NUM_CHARS_PER_DISPLAY_LINE)
+        upper_message = 'Ableton Live'.center(NUM_CHARS_PER_DISPLAY_LINE)
         self.send_display_string(upper_message, 0, 0)
-        lower_message = "Device is offline".center(NUM_CHARS_PER_DISPLAY_LINE)
+        lower_message = 'Device is offline'.center(NUM_CHARS_PER_DISPLAY_LINE)
         self.send_display_string(lower_message, 1, 0)
         MackieControlComponent.destroy(self)
 
     def stack_offset(self):
-        return self._MainDisplay__stack_offset
+        return self.__stack_offset
 
     def set_stack_offset(self, offset):
-        self._MainDisplay__stack_offset = offset
+        pass
+        self.__stack_offset = offset
 
     def send_display_string(self, display_string, display_row, cursor_offset):
         if display_row == 0:
             offset = cursor_offset
-        else:
-            if display_row == 1:
-                offset = NUM_CHARS_PER_DISPLAY_LINE + 2 + cursor_offset
+        elif display_row == 1:
+            offset = NUM_CHARS_PER_DISPLAY_LINE + 2 + cursor_offset
+        message_string = as_ascii(display_string)
+        if self.__last_send_messages[display_row] != message_string:
+            self.__last_send_messages[display_row] = message_string
+            if self.main_script().is_extension():
+                device_type = SYSEX_DEVICE_TYPE_XT
             else:
-                message_string = as_ascii(display_string)
-                if self._MainDisplay__last_send_messages[display_row] != message_string:
-                    self._MainDisplay__last_send_messages[display_row] = message_string
-                    if self.main_script().is_extension():
-                        device_type = SYSEX_DEVICE_TYPE_XT
-                    else:
-                        device_type = SYSEX_DEVICE_TYPE
-                    display_sysex = (
-                     240, 0, 0, 102, device_type, 18, offset) + tuple(message_string) + (247, )
-                    self.send_midi(display_sysex)
+                device_type = SYSEX_DEVICE_TYPE
+            display_sysex = (240, 0, 0, 102, device_type, 18, offset) + tuple(message_string) + (247,)
+            self.send_midi(display_sysex)
 
     def refresh_state(self):
-        self._MainDisplay__last_send_messages = [[], []]
+        self.__last_send_messages = [[], []]
 
     def on_update_display_timer(self):
-        pass
+        return

--- a/MackieControl/MainDisplayController.py
+++ b/MackieControl/MainDisplayController.py
@@ -1,157 +1,161 @@
-# uncompyle6 version 3.9.1
-# Python bytecode version base 3.7.0 (3394)
-# Decompiled from: Python 3.12.2 (main, Feb  6 2024, 20:19:44) [Clang 15.0.0 (clang-1500.1.0.2.5)]
-# Embedded file name: output/Live/mac_universal_64_static/Release/python-bundle/MIDI Remote Scripts/MackieControl/MainDisplayController.py
-# Compiled at: 2024-03-09 01:30:22
-# Size of source mod 2**32: 9866 bytes
-from __future__ import absolute_import, print_function, unicode_literals
-from builtins import range, str
+# Decompiled with PyLingual (https://pylingual.io)
+# Internal filename: ..\..\..\output\Live\win_64_static\Release\python-bundle\MIDI Remote Scripts\MackieControl\MainDisplayController.py
+# Bytecode version: 3.11a7e (3495)
+# Source timestamp: 2024-09-26 15:27:47 UTC (1727364467)
+
 from .MackieControlComponent import *
 
+
 class MainDisplayController(MackieControlComponent):
+    pass
 
     def __init__(self, main_script, display):
         MackieControlComponent.__init__(self, main_script)
-        self._MainDisplayController__left_extensions = []
-        self._MainDisplayController__right_extensions = []
-        self._MainDisplayController__displays = [
-         display]
-        self._MainDisplayController__own_display = display
-        self._MainDisplayController__parameters = [[] for x in range(NUM_CHANNEL_STRIPS)]
-        self._MainDisplayController__channel_strip_strings = ["" for x in range(NUM_CHANNEL_STRIPS)]
-        self._MainDisplayController__channel_strip_mode = True
-        self._MainDisplayController__show_parameter_names = False
-        self._MainDisplayController__bank_channel_offset = 0
-        self._MainDisplayController__meters_enabled = False
-        self._MainDisplayController__show_return_tracks = False
+        self.__left_extensions = []
+        self.__right_extensions = []
+        self.__displays = [display]
+        self.__own_display = display
+        self.__parameters = [[] for x in range(NUM_CHANNEL_STRIPS)]
+        self.__channel_strip_strings = ['' for x in range(NUM_CHANNEL_STRIPS)]
+        self.__channel_strip_mode = True
+        self.__show_parameter_names = False
+        self.__bank_channel_offset = 0
+        self.__meters_enabled = False
+        self.__show_return_tracks = False
 
     def destroy(self):
         self.enable_meters(False)
         MackieControlComponent.destroy(self)
 
     def set_controller_extensions(self, left_extensions, right_extensions):
-        self._MainDisplayController__left_extensions = left_extensions
-        self._MainDisplayController__right_extensions = right_extensions
-        self._MainDisplayController__displays = []
+        pass
+        self.__left_extensions = left_extensions
+        self.__right_extensions = right_extensions
+        self.__displays = []
         stack_offset = 0
         for le in left_extensions:
-            self._MainDisplayController__displays.append(le.main_display())
+            self.__displays.append(le.main_display())
             le.main_display().set_stack_offset(stack_offset)
             stack_offset += NUM_CHANNEL_STRIPS
-
-        self._MainDisplayController__displays.append(self._MainDisplayController__own_display)
-        self._MainDisplayController__own_display.set_stack_offset(stack_offset)
+        self.__displays.append(self.__own_display)
+        self.__own_display.set_stack_offset(stack_offset)
         stack_offset += NUM_CHANNEL_STRIPS
         for re in right_extensions:
-            self._MainDisplayController__displays.append(re.main_display())
+            self.__displays.append(re.main_display())
             re.main_display().set_stack_offset(stack_offset)
             stack_offset += NUM_CHANNEL_STRIPS
-
-        self._MainDisplayController__parameters = [[] for x in range(len(self._MainDisplayController__displays) * NUM_CHANNEL_STRIPS)]
-        self._MainDisplayController__channel_strip_strings = ["" for x in range(len(self._MainDisplayController__displays) * NUM_CHANNEL_STRIPS)]
+        self.__parameters = [[] for x in
+                             range(len(self.__displays) * NUM_CHANNEL_STRIPS)]
+        self.__channel_strip_strings = ['' for x in range(
+            len(self.__displays) * NUM_CHANNEL_STRIPS)]
         self.refresh_state()
 
     def enable_meters(self, enabled):
-        if self._MainDisplayController__meters_enabled != enabled:
-            self._MainDisplayController__meters_enabled = enabled
+        if self.__meters_enabled != enabled:
+            self.__meters_enabled = enabled
             self.refresh_state()
 
     def set_show_parameter_names(self, enable):
-        self._MainDisplayController__show_parameter_names = enable
+        self.__show_parameter_names = enable
 
     def set_channel_offset(self, channel_offset):
-        self._MainDisplayController__bank_channel_offset = channel_offset
+        self.__bank_channel_offset = channel_offset
 
     def parameters(self):
-        return self._MainDisplayController__parameters
+        return self.__parameters
 
     def set_parameters(self, parameters):
         if parameters:
             self.set_channel_strip_strings(None)
-        for d in self._MainDisplayController__displays:
-            self._MainDisplayController__parameters = parameters
+        for d in self.__displays:
+            self.__parameters = parameters
 
     def channel_strip_strings(self):
-        return self._MainDisplayController__channel_strip_strings
+        return self.__channel_strip_strings
 
     def set_channel_strip_strings(self, channel_strip_strings):
         if channel_strip_strings:
             self.set_parameters(None)
-        self._MainDisplayController__channel_strip_strings = channel_strip_strings
+        self.__channel_strip_strings = channel_strip_strings
 
     def set_show_return_track_names(self, show_returns):
-        self._MainDisplayController__show_return_tracks = show_returns
+        self.__show_return_tracks = show_returns
 
     def refresh_state(self):
-        for d in self._MainDisplayController__displays:
+        for d in self.__displays:
             d.refresh_state()
 
     def on_update_display_timer(self):
         strip_index = 0
-        for display in self._MainDisplayController__displays:
-            if self._MainDisplayController__channel_strip_mode:
-                upper_string = ""
-                lower_string = ""
-                track_index_range = list(range(self._MainDisplayController__bank_channel_offset + display.stack_offset(), self._MainDisplayController__bank_channel_offset + display.stack_offset() + NUM_CHANNEL_STRIPS))
-                if self._MainDisplayController__show_return_tracks:
+        for display in self.__displays:
+            if self.__channel_strip_mode:
+                upper_string = u''
+                lower_string = u''
+                track_index_range = list(
+                    range(self.__bank_channel_offset + display.stack_offset(),
+                          self.__bank_channel_offset + display.stack_offset() + NUM_CHANNEL_STRIPS))
+                if self.__show_return_tracks:
                     tracks = self.song().return_tracks
                 else:
                     tracks = self.song().visible_tracks
                 for t in track_index_range:
-                    if self._MainDisplayController__parameters:
-                        if self._MainDisplayController__show_parameter_names:
-                            if self._MainDisplayController__parameters[strip_index]:
-                                upper_string += self._MainDisplayController__generate_6_char_string(self._MainDisplayController__parameters[strip_index][1])
+                    if self.__parameters and self.__show_parameter_names:
+                        if self.__parameters[strip_index]:
+                            upper_string += self.__generate_6_char_string(
+                                self.__parameters[strip_index][1])
                         else:
-                            upper_string += self._MainDisplayController__generate_6_char_string("")
+                            upper_string += self.__generate_6_char_string(u'')
                     elif t < len(tracks):
-                        upper_string += self._MainDisplayController__generate_6_char_string(tracks[t].name)
+                        upper_string += self.__generate_6_char_string(
+                            tracks[t].name)
                     else:
-                        upper_string += self._MainDisplayController__generate_6_char_string("")
-                    upper_string += " "
-                    if self._MainDisplayController__parameters:
-                        if self._MainDisplayController__parameters[strip_index]:
-                            if self._MainDisplayController__parameters[strip_index][0]:
-                                lower_string += self._MainDisplayController__generate_6_char_string(str(self._MainDisplayController__parameters[strip_index][0]))
+                        upper_string += self.__generate_6_char_string(u'')
+                    upper_string += u' '
+                    if self.__parameters and self.__parameters[strip_index]:
+                        if self.__parameters[strip_index][0]:
+                            lower_string += self.__generate_6_char_string(
+                                str(self.__parameters[strip_index][0]))
                         else:
-                            lower_string += self._MainDisplayController__generate_6_char_string("")
+                            lower_string += self.__generate_6_char_string(u'')
+                    elif self.__channel_strip_strings and \
+                        self.__channel_strip_strings[strip_index]:
+                        lower_string += self.__generate_6_char_string(
+                            self.__channel_strip_strings[strip_index])
                     else:
-                        if self._MainDisplayController__channel_strip_strings and self._MainDisplayController__channel_strip_strings[strip_index]:
-                            lower_string += self._MainDisplayController__generate_6_char_string(self._MainDisplayController__channel_strip_strings[strip_index])
-                        else:
-                            lower_string += self._MainDisplayController__generate_6_char_string("")
-                    lower_string += " "
+                        lower_string += self.__generate_6_char_string(u'')
+                    lower_string += u' '
                     strip_index += 1
 
                 display.send_display_string(upper_string, 0, 0)
-                if not self._MainDisplayController__meters_enabled:
+                if not self.__meters_enabled:
                     display.send_display_string(lower_string, 1, 0)
-                else:
-                    ascii_message = "< _1234 guck ma #!?:;_ >"
-                    if not self._MainDisplayController__test:
-                        self._MainDisplayController__test = 0
             else:
-                self._MainDisplayController__test = self._MainDisplayController__test + 1
-                if self._MainDisplayController__test > NUM_CHARS_PER_DISPLAY_LINE - len(ascii_message):
-                    self._MainDisplayController__test = 0
-                self.send_display_string(ascii_message, 0, self._MainDisplayController__test)
+                ascii_message = u'< _1234 guck ma #!?:;_ >'
+                if not self.__test:
+                    self.__test = 0
+                self.__test = self.__test + 1
+                if self.__test > NUM_CHARS_PER_DISPLAY_LINE - len(
+                    ascii_message):
+                    self.__test = 0
+                self.send_display_string(ascii_message, 0, self.__test)
 
     def __generate_6_char_string(self, display_string):
         if not display_string:
-            return "      "
-            if len(display_string.strip()) > 6:
-                if display_string.endswith("dB"):
-                    if display_string.find(".") != -1:
-                        display_string = display_string[None[:-2]]
-            if len(display_string) > 6:
-                for um in (' ', 'i', 'o', 'u', 'e', 'a'):
-                    while len(display_string) > 6 and display_string.rfind(um, 1) != -1:
-                        um_pos = display_string.rfind(um, 1)
-                        display_string = display_string[None[:um_pos]] + display_string[(um_pos + 1)[:None]]
+            return u'      '
+        if len(display_string.strip()) > 6 and display_string.endswith(
+            u'dB') and display_string.find(u'.') != -1:
+            display_string = display_string[:-2]
+        if len(display_string) > 6:
+            for um in [u' ', u'i', u'o', u'u', u'e', u'a']:
+                while len(display_string) > 6 and display_string.rfind(um,
+                                                                       1) != -1:
+                    um_pos = display_string.rfind(um, 1)
+                    display_string = display_string[:um_pos] + display_string[
+                                                               um_pos + 1:]
 
         else:
             display_string = display_string.center(6)
-        ret = ""
+        ret = u''
         for i in range(6):
             ret += display_string[i]
 

--- a/MackieControl/SoftwareController.py
+++ b/MackieControl/SoftwareController.py
@@ -1,157 +1,160 @@
-# uncompyle6 version 3.9.1
-# Python bytecode version base 3.7.0 (3394)
-# Decompiled from: Python 3.12.2 (main, Feb  6 2024, 20:19:44) [Clang 15.0.0 (clang-1500.1.0.2.5)]
-# Embedded file name: output/Live/mac_universal_64_static/Release/python-bundle/MIDI Remote Scripts/MackieControl/SoftwareController.py
-# Compiled at: 2024-03-09 01:30:22
-# Size of source mod 2**32: 12339 bytes
-from __future__ import absolute_import, print_function, unicode_literals
+# Decompiled with PyLingual (https://pylingual.io)
+# Internal filename: ..\..\..\output\Live\win_64_static\Release\python-bundle\MIDI Remote Scripts\MackieControl\SoftwareController.py
+# Bytecode version: 3.11a7e (3495)
+# Source timestamp: 2024-09-26 15:27:47 UTC (1727364467)
+
 from .MackieControlComponent import *
+
 
 class SoftwareController(MackieControlComponent):
 
     def __init__(self, main_script):
         MackieControlComponent.__init__(self, main_script)
-        self._SoftwareController__last_can_undo_state = False
-        self._SoftwareController__last_can_redo_state = False
+        self.__last_can_undo_state = False
+        self.__last_can_redo_state = False
         av = self.application().view
-        av.add_is_view_visible_listener("Session", self._SoftwareController__update_session_arranger_button_led)
-        av.add_is_view_visible_listener("Detail/Clip", self._SoftwareController__update_detail_sub_view_button_led)
-        av.add_is_view_visible_listener("Browser", self._SoftwareController__update_browser_button_led)
-        av.add_is_view_visible_listener("Detail", self._SoftwareController__update_detail_button_led)
-        self.song().view.add_draw_mode_listener(self._SoftwareController__update_draw_mode_button_led)
-        self.song().view.add_follow_song_listener(self._SoftwareController__update_follow_song_button_led)
-        self.song().add_back_to_arranger_listener(self._SoftwareController__update_back_to_arranger_button_led)
+        av.add_is_view_visible_listener('Session',
+                                        self.__update_session_arranger_button_led)
+        av.add_is_view_visible_listener('Detail/Clip',
+                                        self.__update_detail_sub_view_button_led)
+        av.add_is_view_visible_listener('Browser',
+                                        self.__update_browser_button_led)
+        av.add_is_view_visible_listener('Detail',
+                                        self.__update_detail_button_led)
+        self.song().view.add_draw_mode_listener(
+            self.__update_draw_mode_button_led)
+        self.song().view.add_follow_song_listener(
+            self.__update_follow_song_button_led)
+        self.song().add_back_to_arranger_listener(
+            self.__update_back_to_arranger_button_led)
 
     def destroy(self):
         av = self.application().view
-        av.remove_is_view_visible_listener("Session", self._SoftwareController__update_session_arranger_button_led)
-        av.remove_is_view_visible_listener("Detail/Clip", self._SoftwareController__update_detail_sub_view_button_led)
-        av.remove_is_view_visible_listener("Browser", self._SoftwareController__update_browser_button_led)
-        av.remove_is_view_visible_listener("Detail", self._SoftwareController__update_detail_button_led)
-        self.song().view.remove_draw_mode_listener(self._SoftwareController__update_draw_mode_button_led)
-        self.song().view.remove_follow_song_listener(self._SoftwareController__update_follow_song_button_led)
-        self.song().remove_back_to_arranger_listener(self._SoftwareController__update_back_to_arranger_button_led)
+        av.remove_is_view_visible_listener('Session',
+                                           self.__update_session_arranger_button_led)
+        av.remove_is_view_visible_listener('Detail/Clip',
+                                           self.__update_detail_sub_view_button_led)
+        av.remove_is_view_visible_listener('Browser',
+                                           self.__update_browser_button_led)
+        av.remove_is_view_visible_listener('Detail',
+                                           self.__update_detail_button_led)
+        self.song().view.remove_draw_mode_listener(
+            self.__update_draw_mode_button_led)
+        self.song().view.remove_follow_song_listener(
+            self.__update_follow_song_button_led)
+        self.song().remove_back_to_arranger_listener(
+            self.__update_back_to_arranger_button_led)
         for note in software_controls_switch_ids:
             self.send_midi((NOTE_ON_STATUS, note, BUTTON_STATE_OFF))
-
         for note in function_key_control_switch_ids:
             self.send_midi((NOTE_ON_STATUS, note, BUTTON_STATE_OFF))
-
         MackieControlComponent.destroy(self)
 
     def handle_function_key_switch_ids(self, switch_id, value):
-        pass
+        return
 
     def handle_software_controls_switch_ids(self, switch_id, value):
         if switch_id == SID_MOD_SHIFT:
             self.main_script().set_shift_is_pressed(value == BUTTON_PRESSED)
-        else:
-            if switch_id == SID_MOD_OPTION:
-                self.main_script().set_option_is_pressed(value == BUTTON_PRESSED)
-            else:
-                if switch_id == SID_MOD_CTRL:
-                    self.main_script().set_control_is_pressed(value == BUTTON_PRESSED)
-                else:
-                    if switch_id == SID_MOD_ALT:
-                        self.main_script().set_alt_is_pressed(value == BUTTON_PRESSED)
-                    else:
-                        if switch_id == SID_AUTOMATION_ON:
-                            if value == BUTTON_PRESSED:
-                                self._SoftwareController__toggle_session_arranger_is_visible()
-                        else:
-                            if switch_id == SID_AUTOMATION_RECORD:
-                                if value == BUTTON_PRESSED:
-                                    self._SoftwareController__toggle_detail_sub_view()
-                            else:
-                                if switch_id == SID_AUTOMATION_SNAPSHOT:
-                                    if value == BUTTON_PRESSED:
-                                        self._SoftwareController__toggle_browser_is_visible()
-                                else:
-                                    if switch_id == SID_AUTOMATION_TOUCH:
-                                        if value == BUTTON_PRESSED:
-                                            self._SoftwareController__toggle_detail_is_visible()
-                                    else:
-                                        if switch_id == SID_FUNC_UNDO:
-                                            if value == BUTTON_PRESSED:
-                                                self.song().undo()
-                                        elif switch_id == SID_FUNC_REDO:
-                                            if value == BUTTON_PRESSED:
-                                                self.song().redo()
-                                        elif switch_id == SID_FUNC_CANCEL:
-                                            if value == BUTTON_PRESSED:
-                                                self._SoftwareController__toggle_back_to_arranger()
-                                        elif switch_id == SID_FUNC_ENTER:
-                                            if value == BUTTON_PRESSED:
-                                                self._SoftwareController__toggle_draw_mode()
-                                        elif switch_id == SID_FUNC_MARKER:
-                                            if value == BUTTON_PRESSED:
-                                                self.song().set_or_delete_cue()
-                                        elif switch_id == SID_FUNC_MIXER:
-                                            if value == BUTTON_PRESSED:
-                                                self._SoftwareController__toggle_follow_song()
+        elif switch_id == SID_MOD_OPTION:
+            self.main_script().set_option_is_pressed(value == BUTTON_PRESSED)
+        elif switch_id == SID_MOD_CTRL:
+            self.main_script().set_control_is_pressed(value == BUTTON_PRESSED)
+        elif switch_id == SID_MOD_ALT:
+            self.main_script().set_alt_is_pressed(value == BUTTON_PRESSED)
+        elif switch_id == SID_AUTOMATION_ON:
+            if value == BUTTON_PRESSED:
+                self.__toggle_session_arranger_is_visible()
+        elif switch_id == SID_AUTOMATION_RECORD:
+            if value == BUTTON_PRESSED:
+                self.__toggle_detail_sub_view()
+        elif switch_id == SID_AUTOMATION_SNAPSHOT:
+            if value == BUTTON_PRESSED:
+                self.__toggle_browser_is_visible()
+        elif switch_id == SID_AUTOMATION_TOUCH:
+            if value == BUTTON_PRESSED:
+                self.__toggle_detail_is_visible()
+        elif switch_id == SID_FUNC_UNDO:
+            if value == BUTTON_PRESSED:
+                self.song().undo()
+        elif switch_id == SID_FUNC_REDO:
+            if value == BUTTON_PRESSED:
+                self.song().redo()
+        elif switch_id == SID_FUNC_CANCEL:
+            if value == BUTTON_PRESSED:
+                self.__toggle_back_to_arranger()
+        elif switch_id == SID_FUNC_ENTER:
+            if value == BUTTON_PRESSED:
+                self.__toggle_draw_mode()
+        elif switch_id == SID_FUNC_MARKER:
+            if value == BUTTON_PRESSED:
+                self.song().set_or_delete_cue()
+        elif switch_id == SID_FUNC_MIXER:
+            if value == BUTTON_PRESSED:
+                self.__toggle_follow_song()
 
     def refresh_state(self):
         self.main_script().set_shift_is_pressed(False)
         self.main_script().set_option_is_pressed(False)
         self.main_script().set_control_is_pressed(False)
         self.main_script().set_alt_is_pressed(False)
-        self._SoftwareController__update_session_arranger_button_led()
-        self._SoftwareController__update_detail_sub_view_button_led()
-        self._SoftwareController__update_browser_button_led()
-        self._SoftwareController__update_detail_button_led()
-        self._SoftwareController__update_follow_song_button_led()
-        self._SoftwareController__update_undo_button_led()
-        self._SoftwareController__update_redo_button_led()
-        self._SoftwareController__update_draw_mode_button_led()
-        self._SoftwareController__update_back_to_arranger_button_led()
+        self.__update_session_arranger_button_led()
+        self.__update_detail_sub_view_button_led()
+        self.__update_browser_button_led()
+        self.__update_detail_button_led()
+        self.__update_follow_song_button_led()
+        self.__update_undo_button_led()
+        self.__update_redo_button_led()
+        self.__update_draw_mode_button_led()
+        self.__update_back_to_arranger_button_led()
 
     def on_update_display_timer(self):
-        if self._SoftwareController__last_can_undo_state != self.song().can_undo:
-            self._SoftwareController__last_can_undo_state = self.song().can_undo
-            self._SoftwareController__update_undo_button_led()
-        if self._SoftwareController__last_can_redo_state != self.song().can_redo:
-            self._SoftwareController__last_can_redo_state = self.song().can_redo
-            self._SoftwareController__update_redo_button_led()
+        if self.__last_can_undo_state != self.song().can_undo:
+            self.__last_can_undo_state = self.song().can_undo
+            self.__update_undo_button_led()
+        if self.__last_can_redo_state != self.song().can_redo:
+            self.__last_can_redo_state = self.song().can_redo
+            self.__update_redo_button_led()
 
     def __toggle_session_arranger_is_visible(self):
-        if self.application().view.is_view_visible("Session"):
+        if self.application().view.is_view_visible('Session'):
             if self.shift_is_pressed():
-                self.application().view.focus_view("Session")
+                self.application().view.focus_view('Session')
             else:
-                self.application().view.hide_view("Session")
+                self.application().view.hide_view('Session')
         elif self.shift_is_pressed():
-            self.application().view.focus_view("Arranger")
+            self.application().view.focus_view('Arranger')
         else:
-            self.application().view.hide_view("Arranger")
+            self.application().view.hide_view('Arranger')
 
     def __toggle_detail_sub_view(self):
-        if self.application().view.is_view_visible("Detail/Clip"):
+        if self.application().view.is_view_visible('Detail/Clip'):
             if self.shift_is_pressed():
-                self.application().view.focus_view("Detail/Clip")
+                self.application().view.focus_view('Detail/Clip')
             else:
-                self.application().view.show_view("Detail/DeviceChain")
+                self.application().view.show_view('Detail/DeviceChain')
         elif self.shift_is_pressed():
-            self.application().view.focus_view("Detail/DeviceChain")
+            self.application().view.focus_view('Detail/DeviceChain')
         else:
-            self.application().view.show_view("Detail/Clip")
+            self.application().view.show_view('Detail/Clip')
 
     def __toggle_browser_is_visible(self):
-        if self.application().view.is_view_visible("Browser"):
+        if self.application().view.is_view_visible('Browser'):
             if self.shift_is_pressed():
-                self.application().view.focus_view("Browser")
+                self.application().view.focus_view('Browser')
             else:
-                self.application().view.hide_view("Browser")
+                self.application().view.hide_view('Browser')
         else:
-            self.application().view.show_view("Browser")
+            self.application().view.show_view('Browser')
 
     def __toggle_detail_is_visible(self):
-        if self.application().view.is_view_visible("Detail"):
+        if self.application().view.is_view_visible('Detail'):
             if self.shift_is_pressed():
-                self.application().view.focus_view("Detail")
+                self.application().view.focus_view('Detail')
             else:
-                self.application().view.hide_view("Detail")
+                self.application().view.hide_view('Detail')
         else:
-            self.application().view.show_view("Detail")
+            self.application().view.show_view('Detail')
 
     def __toggle_back_to_arranger(self):
         self.song().back_to_arranger = not self.song().back_to_arranger
@@ -163,28 +166,35 @@ class SoftwareController(MackieControlComponent):
         self.song().view.follow_song = not self.song().view.follow_song
 
     def __update_session_arranger_button_led(self):
-        if self.application().view.is_view_visible("Session"):
+        if self.application().view.is_view_visible('Session'):
             self.send_midi((NOTE_ON_STATUS, SID_AUTOMATION_ON, BUTTON_STATE_ON))
         else:
-            self.send_midi((NOTE_ON_STATUS, SID_AUTOMATION_ON, BUTTON_STATE_OFF))
+            self.send_midi(
+                (NOTE_ON_STATUS, SID_AUTOMATION_ON, BUTTON_STATE_OFF))
 
     def __update_detail_sub_view_button_led(self):
-        if self.application().view.is_view_visible("Detail/Clip"):
-            self.send_midi((NOTE_ON_STATUS, SID_AUTOMATION_RECORD, BUTTON_STATE_ON))
+        if self.application().view.is_view_visible('Detail/Clip'):
+            self.send_midi(
+                (NOTE_ON_STATUS, SID_AUTOMATION_RECORD, BUTTON_STATE_ON))
         else:
-            self.send_midi((NOTE_ON_STATUS, SID_AUTOMATION_RECORD, BUTTON_STATE_OFF))
+            self.send_midi(
+                (NOTE_ON_STATUS, SID_AUTOMATION_RECORD, BUTTON_STATE_OFF))
 
     def __update_browser_button_led(self):
-        if self.application().view.is_view_visible("Browser"):
-            self.send_midi((NOTE_ON_STATUS, SID_AUTOMATION_SNAPSHOT, BUTTON_STATE_ON))
+        if self.application().view.is_view_visible('Browser'):
+            self.send_midi(
+                (NOTE_ON_STATUS, SID_AUTOMATION_SNAPSHOT, BUTTON_STATE_ON))
         else:
-            self.send_midi((NOTE_ON_STATUS, SID_AUTOMATION_SNAPSHOT, BUTTON_STATE_OFF))
+            self.send_midi(
+                (NOTE_ON_STATUS, SID_AUTOMATION_SNAPSHOT, BUTTON_STATE_OFF))
 
     def __update_detail_button_led(self):
-        if self.application().view.is_view_visible("Detail"):
-            self.send_midi((NOTE_ON_STATUS, SID_AUTOMATION_TOUCH, BUTTON_STATE_ON))
+        if self.application().view.is_view_visible('Detail'):
+            self.send_midi(
+                (NOTE_ON_STATUS, SID_AUTOMATION_TOUCH, BUTTON_STATE_ON))
         else:
-            self.send_midi((NOTE_ON_STATUS, SID_AUTOMATION_TOUCH, BUTTON_STATE_OFF))
+            self.send_midi(
+                (NOTE_ON_STATUS, SID_AUTOMATION_TOUCH, BUTTON_STATE_OFF))
 
     def __update_follow_song_button_led(self):
         if self.song().view.follow_song:

--- a/MackieControl/TimeDisplay.py
+++ b/MackieControl/TimeDisplay.py
@@ -1,21 +1,19 @@
-# uncompyle6 version 3.9.1
-# Python bytecode version base 3.7.0 (3394)
-# Decompiled from: Python 3.12.2 (main, Feb  6 2024, 20:19:44) [Clang 15.0.0 (clang-1500.1.0.2.5)]
-# Embedded file name: output/Live/mac_universal_64_static/Release/python-bundle/MIDI Remote Scripts/MackieControl/TimeDisplay.py
-# Compiled at: 2024-03-09 01:30:22
-# Size of source mod 2**32: 3956 bytes
-from __future__ import absolute_import, print_function, unicode_literals
-from builtins import range, str
+# Decompiled with PyLingual (https://pylingual.io)
+# Internal filename: ..\..\..\output\Live\win_64_static\Release\python-bundle\MIDI Remote Scripts\MackieControl\TimeDisplay.py
+# Bytecode version: 3.11a7e (3495)
+# Source timestamp: 2024-09-26 15:27:47 UTC (1727364467)
+import Live
+
 from .MackieControlComponent import *
 
-class TimeDisplay(MackieControlComponent):
 
+class TimeDisplay(MackieControlComponent):
     def __init__(self, main_script):
         MackieControlComponent.__init__(self, main_script)
-        self._TimeDisplay__main_script = main_script
-        self._TimeDisplay__show_beat_time = False
-        self._TimeDisplay__smpt_format = Live.Song.TimeFormat.smpte_25
-        self._TimeDisplay__last_send_time = []
+        self.__main_script = main_script
+        self.__show_beat_time = False
+        self.__smpt_format = Live.Song.TimeFormat.smpte_25
+        self.__last_send_time = []
         self.show_beats()
 
     def destroy(self):
@@ -23,47 +21,49 @@ class TimeDisplay(MackieControlComponent):
         MackieControlComponent.destroy(self)
 
     def show_beats(self):
-        self._TimeDisplay__show_beat_time = True
+        self.__show_beat_time = True
         self.send_midi((NOTE_ON_STATUS, SELECT_BEATS_NOTE, BUTTON_STATE_ON))
         self.send_midi((NOTE_ON_STATUS, SELECT_SMPTE_NOTE, BUTTON_STATE_OFF))
 
     def show_smpte(self, smpte_mode):
-        self._TimeDisplay__show_beat_time = False
-        self._TimeDisplay__smpt_format = smpte_mode
+        self.__show_beat_time = False
+        self.__smpt_format = smpte_mode
         self.send_midi((NOTE_ON_STATUS, SELECT_BEATS_NOTE, BUTTON_STATE_OFF))
         self.send_midi((NOTE_ON_STATUS, SELECT_SMPTE_NOTE, BUTTON_STATE_ON))
 
     def toggle_mode(self):
-        if self._TimeDisplay__show_beat_time:
-            self.show_smpte(self._TimeDisplay__smpt_format)
+        if self.__show_beat_time:
+            self.show_smpte(self.__smpt_format)
         else:
             self.show_beats()
 
     def clear_display(self):
-        time_string = [" " for i in range(10)]
-        self._TimeDisplay__send_time_string(time_string, show_points=False)
+        time_string = [' ' for i in range(10)]
+        self.__send_time_string(time_string, show_points=False)
         self.send_midi((NOTE_ON_STATUS, SELECT_BEATS_NOTE, BUTTON_STATE_OFF))
         self.send_midi((NOTE_ON_STATUS, SELECT_SMPTE_NOTE, BUTTON_STATE_OFF))
 
     def refresh_state(self):
         self.show_beats()
-        self._TimeDisplay__last_send_time = []
+        self.__last_send_time = []
 
     def on_update_display_timer(self):
-        if self._TimeDisplay__show_beat_time:
+        pass
+        pass
+        if self.__show_beat_time:
             time_string = str(self.song().get_current_beats_song_time())
         else:
-            time_string = str(self.song().get_current_smpte_song_time(self._TimeDisplay__smpt_format))
-        time_string = [c for c in time_string if c not in ('.', ':')]
-        if self._TimeDisplay__last_send_time != time_string:
-            self._TimeDisplay__last_send_time = time_string
-            self._TimeDisplay__send_time_string(time_string, show_points=True)
+            time_string = str(
+                self.song().get_current_smpte_song_time(self.__smpt_format))
+        time_string = [c for c in time_string if c not in ['.', ':']]
+        if self.__last_send_time != time_string:
+            self.__last_send_time = time_string
+            self.__send_time_string(time_string, show_points=True)
 
     def __send_time_string(self, time_string, show_points):
         for c in range(0, 10):
             char = time_string[9 - c].upper()
             char_code = g7_seg_led_conv_table[char]
-            if show_points:
-                if c in (3, 5, 7):
-                    char_code += 64
+            if show_points and c in [3, 5, 7]:
+                char_code += 64
             self.send_midi((176, 64 + c, char_code))

--- a/MackieControl/Transport.py
+++ b/MackieControl/Transport.py
@@ -99,14 +99,14 @@ class Transport(MackieControlComponent):
                     self.____fast_forward_counter += 1
                     self.__fast___rewind_counter -= 4
                     if not self.alt_is_pressed():
-                        self.__fast_forward(base_acceleration + max(1, self.____fast_forward_counter/4))
+                        self.__fast_forward(base_acceleration + max(1, self.____fast_forward_counter//4))
                     else:
                         self.__fast_forward(base_acceleration)
                 if self.____rewind_button_down:
                     self.__fast___rewind_counter += 1
                     self.____fast_forward_counter -= 4
                     if not self.alt_is_pressed():
-                        self.__rewind(base_acceleration + max(1, self.__fast___rewind_counter/4))
+                        self.__rewind(base_acceleration + max(1, self.__fast___rewind_counter//4))
                     else:
                         self.__rewind(base_acceleration)
         else:

--- a/MackieControl/Transport.py
+++ b/MackieControl/Transport.py
@@ -1,193 +1,185 @@
-# uncompyle6 version 3.9.1
-# Python bytecode version base 3.7.0 (3394)
-# Decompiled from: Python 3.12.2 (main, Feb  6 2024, 20:19:44) [Clang 15.0.0 (clang-1500.1.0.2.5)]
-# Embedded file name: output/Live/mac_universal_64_static/Release/python-bundle/MIDI Remote Scripts/MackieControl/Transport.py
-# Compiled at: 2024-03-09 01:30:22
-# Size of source mod 2**32: 25148 bytes
-from __future__ import absolute_import, division, print_function, unicode_literals
-from past.utils import old_div
+# Decompiled with PyLingual (https://pylingual.io)
+# Internal filename: ..\..\..\output\Live\win_64_static\Release\python-bundle\MIDI Remote Scripts\MackieControl\Transport.py
+# Bytecode version: 3.11a7e (3495)
+# Source timestamp: 2024-09-26 15:27:47 UTC (1727364467)
+
 from ableton.v2.base import move_current_song_time
 from .MackieControlComponent import *
+import Live
 
 class Transport(MackieControlComponent):
 
     def __init__(self, main_script):
         MackieControlComponent.__init__(self, main_script)
-        self._Transport__forward_button_down = False
-        self._Transport____rewind_button_down = False
-        self._Transport__zoom_button_down = False
-        self._Transport__scrub_button_down = False
-        self._Transport__cursor_left_is_down = False
-        self._Transport__cursor_right_is_down = False
-        self._Transport__cursor_up_is_down = False
-        self._Transport__cursor_down_is_down = False
-        self._Transport__cursor_repeat_delay = 0
-        self._Transport__transport_repeat_delay = 0
-        self._Transport____fast_forward_counter = 0
-        self._Transport__fast___rewind_counter = 0
-        self._Transport__jog_step_count_forward = 0
-        self._Transport__jog_step_count_backwards = 0
-        self._Transport__last_focussed_clip_play_state = CLIP_STATE_INVALID
-        self.song().add_record_mode_listener(self._Transport__update_record_button_led)
-        self.song().add_is_playing_listener(self._Transport__update_play_button_led)
-        self.song().add_loop_listener(self._Transport__update_loop_button_led)
-        self.song().add_punch_out_listener(self._Transport__update_punch_out_button_led)
-        self.song().add_punch_in_listener(self._Transport__update_punch_in_button_led)
-        self.song().add_can_jump_to_prev_cue_listener(self._Transport__update_prev_cue_button_led)
-        self.song().add_can_jump_to_next_cue_listener(self._Transport__update_next_cue_button_led)
-        self.application().view.add_is_view_visible_listener("Session", self._Transport__on_session_is_visible_changed)
+        self.__forward_button_down = False
+        self.____rewind_button_down = False
+        self.__zoom_button_down = False
+        self.__scrub_button_down = False
+        self.__cursor_left_is_down = False
+        self.__cursor_right_is_down = False
+        self.__cursor_up_is_down = False
+        self.__cursor_down_is_down = False
+        self.__cursor_repeat_delay = 0
+        self.__transport_repeat_delay = 0
+        self.____fast_forward_counter = 0
+        self.__fast___rewind_counter = 0
+        self.__jog_step_count_forward = 0
+        self.__jog_step_count_backwards = 0
+        self.__last_focussed_clip_play_state = CLIP_STATE_INVALID
+        self.song().add_record_mode_listener(self.__update_record_button_led)
+        self.song().add_is_playing_listener(self.__update_play_button_led)
+        self.song().add_loop_listener(self.__update_loop_button_led)
+        self.song().add_punch_out_listener(self.__update_punch_out_button_led)
+        self.song().add_punch_in_listener(self.__update_punch_in_button_led)
+        self.song().add_can_jump_to_prev_cue_listener(self.__update_prev_cue_button_led)
+        self.song().add_can_jump_to_next_cue_listener(self.__update_next_cue_button_led)
+        self.application().view.add_is_view_visible_listener('Session', self.__on_session_is_visible_changed)
         self.refresh_state()
 
     def destroy(self):
-        self.song().remove_record_mode_listener(self._Transport__update_record_button_led)
-        self.song().remove_is_playing_listener(self._Transport__update_play_button_led)
-        self.song().remove_loop_listener(self._Transport__update_loop_button_led)
-        self.song().remove_punch_out_listener(self._Transport__update_punch_out_button_led)
-        self.song().remove_punch_in_listener(self._Transport__update_punch_in_button_led)
-        self.song().remove_can_jump_to_prev_cue_listener(self._Transport__update_prev_cue_button_led)
-        self.song().remove_can_jump_to_next_cue_listener(self._Transport__update_next_cue_button_led)
-        self.application().view.remove_is_view_visible_listener("Session", self._Transport__on_session_is_visible_changed)
+        self.song().remove_record_mode_listener(self.__update_record_button_led)
+        self.song().remove_is_playing_listener(self.__update_play_button_led)
+        self.song().remove_loop_listener(self.__update_loop_button_led)
+        self.song().remove_punch_out_listener(self.__update_punch_out_button_led)
+        self.song().remove_punch_in_listener(self.__update_punch_in_button_led)
+        self.song().remove_can_jump_to_prev_cue_listener(self.__update_prev_cue_button_led)
+        self.song().remove_can_jump_to_next_cue_listener(self.__update_next_cue_button_led)
+        self.application().view.remove_is_view_visible_listener('Session', self.__on_session_is_visible_changed)
         for note in transport_control_switch_ids:
             self.send_midi((NOTE_ON_STATUS, note, BUTTON_STATE_OFF))
-
         for note in jog_wheel_switch_ids:
             self.send_midi((NOTE_ON_STATUS, note, BUTTON_STATE_OFF))
-
         for note in marker_control_switch_ids:
             self.send_midi((NOTE_ON_STATUS, note, BUTTON_STATE_OFF))
-
         MackieControlComponent.destroy(self)
 
     def refresh_state(self):
-        self._Transport__update_play_button_led()
-        self._Transport__update_record_button_led()
-        self._Transport__update_prev_cue_button_led()
-        self._Transport__update_next_cue_button_led()
-        self._Transport__update_loop_button_led()
-        self._Transport__update_punch_in_button_led()
-        self._Transport__update_punch_out_button_led()
-        self._Transport__forward_button_down = False
-        self._Transport____rewind_button_down = False
-        self._Transport__zoom_button_down = False
-        self._Transport__scrub_button_down = False
-        self._Transport__cursor_left_is_down = False
-        self._Transport__cursor_right_is_down = False
-        self._Transport__cursor_up_is_down = False
-        self._Transport__cursor_down_is_down = False
-        self._Transport__cursor_repeat_delay = 0
-        self._Transport__transport_repeat_delay = 0
-        self._Transport____fast_forward_counter = 0
-        self._Transport__fast___rewind_counter = 0
-        self._Transport__jog_step_count_forward = 0
-        self._Transport__jog_step_count_backwards = 0
-        self._Transport__last_focussed_clip_play_state = CLIP_STATE_INVALID
-        self._Transport__update_forward_rewind_leds()
-        self._Transport__update_zoom_button_led()
-        self._Transport__update_scrub_button_led()
+        self.__update_play_button_led()
+        self.__update_record_button_led()
+        self.__update_prev_cue_button_led()
+        self.__update_next_cue_button_led()
+        self.__update_loop_button_led()
+        self.__update_punch_in_button_led()
+        self.__update_punch_out_button_led()
+        self.__forward_button_down = False
+        self.____rewind_button_down = False
+        self.__zoom_button_down = False
+        self.__scrub_button_down = False
+        self.__cursor_left_is_down = False
+        self.__cursor_right_is_down = False
+        self.__cursor_up_is_down = False
+        self.__cursor_down_is_down = False
+        self.__cursor_repeat_delay = 0
+        self.__transport_repeat_delay = 0
+        self.____fast_forward_counter = 0
+        self.__fast___rewind_counter = 0
+        self.__jog_step_count_forward = 0
+        self.__jog_step_count_backwards = 0
+        self.__last_focussed_clip_play_state = CLIP_STATE_INVALID
+        self.__update_forward_rewind_leds()
+        self.__update_zoom_button_led()
+        self.__update_scrub_button_led()
 
     def session_is_visible(self):
-        return self.application().view.is_view_visible("Session")
+        return self.application().view.is_view_visible('Session')
 
     def selected_clip_slot(self):
         return self.song().view.highlighted_clip_slot
 
     def on_update_display_timer(self):
-        if self._Transport__transport_repeat_delay > 2:
+        if self.__transport_repeat_delay > 2:
             if self.alt_is_pressed():
                 base_acceleration = 1
             else:
                 base_acceleration = self.song().signature_numerator
             if self.song().is_playing:
                 base_acceleration *= 4
-            elif self._Transport__forward_button_down:
-                if self._Transport____rewind_button_down or self._Transport__forward_button_down:
-                    self._Transport____fast_forward_counter += 1
-                    self._Transport__fast___rewind_counter -= 4
-                    self.alt_is_pressed() or self._Transport__fast_forward(base_acceleration + max(1, old_div(self._Transport____fast_forward_counter, 4)))
-                else:
-                    self._Transport__fast_forward(base_acceleration)
-                if self._Transport____rewind_button_down:
-                    self._Transport__fast___rewind_counter += 1
-                    self._Transport____fast_forward_counter -= 4
+            if not self.__forward_button_down or not self.____rewind_button_down:
+                if self.__forward_button_down:
+                    self.____fast_forward_counter += 1
+                    self.__fast___rewind_counter -= 4
                     if not self.alt_is_pressed():
-                        self._Transport__rewind(base_acceleration + max(1, old_div(self._Transport__fast___rewind_counter, 4)))
+                        self.__fast_forward(base_acceleration + max(1, self.____fast_forward_counter/4))
                     else:
-                        self._Transport__rewind(base_acceleration)
-            else:
-                self._Transport__transport_repeat_delay += 1
-            if self._Transport__cursor_repeat_delay > 2:
-                if self._Transport__cursor_left_is_down:
-                    self._Transport__on_cursor_left_pressed()
-                if self._Transport__cursor_right_is_down:
-                    self._Transport__on_cursor_right_pressed()
-                if self._Transport__cursor_up_is_down:
-                    self._Transport__on_cursor_up_pressed()
-                if self._Transport__cursor_down_is_down:
-                    self._Transport__on_cursor_down_pressed()
+                        self.__fast_forward(base_acceleration)
+                if self.____rewind_button_down:
+                    self.__fast___rewind_counter += 1
+                    self.____fast_forward_counter -= 4
+                    if not self.alt_is_pressed():
+                        self.__rewind(base_acceleration + max(1, self.__fast___rewind_counter/4))
+                    else:
+                        self.__rewind(base_acceleration)
         else:
-            self._Transport__cursor_repeat_delay += 1
+            self.__transport_repeat_delay += 1
+        if self.__cursor_repeat_delay > 2:
+            if self.__cursor_left_is_down:
+                self.__on_cursor_left_pressed()
+            if self.__cursor_right_is_down:
+                self.__on_cursor_right_pressed()
+            if self.__cursor_up_is_down:
+                self.__on_cursor_up_pressed()
+            if self.__cursor_down_is_down:
+                self.__on_cursor_down_pressed()
+        else:
+            self.__cursor_repeat_delay += 1
         if self.session_is_visible():
-            self._Transport__update_zoom_led_in_session()
+            self.__update_zoom_led_in_session()
 
     def handle_marker_switch_ids(self, switch_id, value):
         if switch_id == SID_MARKER_FROM_PREV:
             if value == BUTTON_PRESSED:
-                self._Transport__jump_to_prev_cue()
+                self.__jump_to_prev_cue()
         elif switch_id == SID_MARKER_FROM_NEXT:
             if value == BUTTON_PRESSED:
-                self._Transport__jump_to_next_cue()
+                self.__jump_to_next_cue()
         elif switch_id == SID_MARKER_LOOP:
             if value == BUTTON_PRESSED:
-                self._Transport__toggle_loop()
+                self.__toggle_loop()
         elif switch_id == SID_MARKER_PI:
             if value == BUTTON_PRESSED:
                 if self.control_is_pressed():
-                    self._Transport__set_loopstart_from_cur_position()
+                    self.__set_loopstart_from_cur_position()
                 else:
-                    self._Transport__toggle_punch_in()
+                    self.__toggle_punch_in()
         elif switch_id == SID_MARKER_PO:
             if value == BUTTON_PRESSED:
                 if self.control_is_pressed():
-                    self._Transport__set_loopend_from_cur_position()
+                    self.__set_loopend_from_cur_position()
                 else:
-                    self._Transport__toggle_punch_out()
+                    self.__toggle_punch_out()
         elif switch_id == SID_MARKER_HOME:
             if value == BUTTON_PRESSED:
-                self._Transport__goto_home()
+                self.__goto_home()
         elif switch_id == SID_MARKER_END:
             if value == BUTTON_PRESSED:
-                self._Transport__goto_end()
+                self.__goto_end()
 
     def handle_transport_switch_ids(self, switch_id, value):
         if switch_id == SID_TRANSPORT_REWIND:
             if value == BUTTON_PRESSED:
-                self._Transport__rewind()
-                self._Transport____rewind_button_down = True
-            else:
-                if value == BUTTON_RELEASED:
-                    self._Transport____rewind_button_down = False
-                    self._Transport__fast___rewind_counter = 0
-            self._Transport__update_forward_rewind_leds()
-        else:
-            if switch_id == SID_TRANSPORT_FAST_FORWARD:
-                if value == BUTTON_PRESSED:
-                    self._Transport__fast_forward()
-                    self._Transport__forward_button_down = True
-                else:
-                    if value == BUTTON_RELEASED:
-                        self._Transport__forward_button_down = False
-                        self._Transport____fast_forward_counter = 0
-                self._Transport__update_forward_rewind_leds()
-            else:
-                if switch_id == SID_TRANSPORT_STOP:
-                    if value == BUTTON_PRESSED:
-                        self._Transport__stop_song()
-                elif switch_id == SID_TRANSPORT_PLAY:
-                    if value == BUTTON_PRESSED:
-                        self._Transport__start_song()
-                elif switch_id == SID_TRANSPORT_RECORD:
-                    if value == BUTTON_PRESSED:
-                        self._Transport__toggle_record()
+                self.__rewind()
+                self.____rewind_button_down = True
+            elif value == BUTTON_RELEASED:
+                self.____rewind_button_down = False
+                self.__fast___rewind_counter = 0
+            self.__update_forward_rewind_leds()
+        elif switch_id == SID_TRANSPORT_FAST_FORWARD:
+            if value == BUTTON_PRESSED:
+                self.__fast_forward()
+                self.__forward_button_down = True
+            elif value == BUTTON_RELEASED:
+                self.__forward_button_down = False
+                self.____fast_forward_counter = 0
+            self.__update_forward_rewind_leds()
+        elif switch_id == SID_TRANSPORT_STOP:
+            if value == BUTTON_PRESSED:
+                self.__stop_song()
+        elif switch_id == SID_TRANSPORT_PLAY:
+            if value == BUTTON_PRESSED:
+                self.__start_song()
+        elif switch_id == SID_TRANSPORT_RECORD:
+            if value == BUTTON_PRESSED:
+                self.__toggle_record()
 
     def handle_jog_wheel_rotation(self, value):
         backwards = value >= 64
@@ -202,129 +194,117 @@ class Transport(MackieControlComponent):
                 amount = value
             tempo = max(20, min(999, self.song().tempo + amount * step))
             self.song().tempo = tempo
-        else:
-            if self.session_is_visible():
-                num_steps_per_session_scroll = 4
-                if backwards:
-                    self._Transport__jog_step_count_backwards += 1
-                    if self._Transport__jog_step_count_backwards >= num_steps_per_session_scroll:
-                        self._Transport__jog_step_count_backwards = 0
-                        step = -1
-                    else:
-                        step = 0
+        elif self.session_is_visible():
+            num_steps_per_session_scroll = 4
+            if backwards:
+                self.__jog_step_count_backwards += 1
+                if self.__jog_step_count_backwards >= num_steps_per_session_scroll:
+                    self.__jog_step_count_backwards = 0
+                    step = -1
                 else:
-                    self._Transport__jog_step_count_forward += 1
-                    if self._Transport__jog_step_count_forward >= num_steps_per_session_scroll:
-                        self._Transport__jog_step_count_forward = 0
-                        step = 1
-                    else:
-                        step = 0
-                if step:
-                    new_index = list(self.song().scenes).index(self.song().view.selected_scene) + step
-                    new_index = min(len(self.song().scenes) - 1, max(0, new_index))
-                    self.song().view.selected_scene = self.song().scenes[new_index]
+                    step = 0
             else:
-                if backwards:
-                    step = max(1.0, (value - 64) / 2.0)
+                self.__jog_step_count_forward += 1
+                if self.__jog_step_count_forward >= num_steps_per_session_scroll:
+                    self.__jog_step_count_forward = 0
+                    step = 1
                 else:
-                    step = max(1.0, value / 2.0)
-                if self.song().is_playing:
-                    step *= 4.0
-                if self.alt_is_pressed():
-                    step /= 4.0
-                move_current_song_time((self.song()),
-                  (-step if backwards else step), truncate_to_beat=False)
+                    step = 0
+            if step:
+                new_index = list(self.song().scenes).index(self.song().view.selected_scene) + step
+                new_index = min(len(self.song().scenes) - 1, max(0, new_index))
+                self.song().view.selected_scene = self.song().scenes[new_index]
+        else:
+            if backwards:
+                step = max(1.0, (value - 64) / 2.0)
+            else:
+                step = max(1.0, value / 2.0)
+            if self.song().is_playing:
+                step *= 4.0
+            if self.alt_is_pressed():
+                step /= 4.0
+            move_current_song_time(self.song(), -step if backwards else step, truncate_to_beat=False)
 
     def handle_jog_wheel_switch_ids(self, switch_id, value):
         if switch_id == SID_JOG_CURSOR_UP:
             if value == BUTTON_PRESSED:
-                self._Transport__cursor_up_is_down = True
-                self._Transport__cursor_repeat_delay = 0
-                self._Transport__on_cursor_up_pressed()
-            else:
-                if value == BUTTON_RELEASED:
-                    self._Transport__cursor_up_is_down = False
-        else:
-            if switch_id == SID_JOG_CURSOR_DOWN:
-                if value == BUTTON_PRESSED:
-                    self._Transport__cursor_down_is_down = True
-                    self._Transport__cursor_repeat_delay = 0
-                    self._Transport__on_cursor_down_pressed()
-                else:
-                    if value == BUTTON_RELEASED:
-                        self._Transport__cursor_down_is_down = False
-            else:
-                if switch_id == SID_JOG_CURSOR_LEFT:
-                    if value == BUTTON_PRESSED:
-                        self._Transport__cursor_left_is_down = True
-                        self._Transport__cursor_repeat_delay = 0
-                        self._Transport__on_cursor_left_pressed()
-                    else:
-                        if value == BUTTON_RELEASED:
-                            self._Transport__cursor_left_is_down = False
-                else:
-                    if switch_id == SID_JOG_CURSOR_RIGHT:
-                        if value == BUTTON_PRESSED:
-                            self._Transport__cursor_right_is_down = True
-                            self._Transport__cursor_repeat_delay = 0
-                            self._Transport__on_cursor_right_pressed()
+                self.__cursor_up_is_down = True
+                self.__cursor_repeat_delay = 0
+                self.__on_cursor_up_pressed()
+            elif value == BUTTON_RELEASED:
+                self.__cursor_up_is_down = False
+        elif switch_id == SID_JOG_CURSOR_DOWN:
+            if value == BUTTON_PRESSED:
+                self.__cursor_down_is_down = True
+                self.__cursor_repeat_delay = 0
+                self.__on_cursor_down_pressed()
+            elif value == BUTTON_RELEASED:
+                self.__cursor_down_is_down = False
+        elif switch_id == SID_JOG_CURSOR_LEFT:
+            if value == BUTTON_PRESSED:
+                self.__cursor_left_is_down = True
+                self.__cursor_repeat_delay = 0
+                self.__on_cursor_left_pressed()
+            elif value == BUTTON_RELEASED:
+                self.__cursor_left_is_down = False
+        elif switch_id == SID_JOG_CURSOR_RIGHT:
+            if value == BUTTON_PRESSED:
+                self.__cursor_right_is_down = True
+                self.__cursor_repeat_delay = 0
+                self.__on_cursor_right_pressed()
+            elif value == BUTTON_RELEASED:
+                self.__cursor_right_is_down = False
+        elif switch_id == SID_JOG_ZOOM:
+            if value == BUTTON_PRESSED:
+                if self.session_is_visible():
+                    if self.selected_clip_slot():
+                        if self.alt_is_pressed():
+                            self.selected_clip_slot().has_stop_button = not self.selected_clip_slot().has_stop_button
+                        elif self.option_is_pressed():
+                            self.selected_clip_slot().stop()
                         else:
-                            if value == BUTTON_RELEASED:
-                                self._Transport__cursor_right_is_down = False
+                            self.selected_clip_slot().fire()
+                else:
+                    self.__zoom_button_down = not self.__zoom_button_down
+                    self.__update_zoom_button_led()
+        elif switch_id == SID_JOG_SCRUB:
+            if value == BUTTON_PRESSED:
+                if self.session_is_visible():
+                    if self.option_is_pressed():
+                        self.song().stop_all_clips()
                     else:
-                        if switch_id == SID_JOG_ZOOM:
-                            if value == BUTTON_PRESSED:
-                                if self.session_is_visible():
-                                    if self.selected_clip_slot():
-                                        if self.alt_is_pressed():
-                                            self.selected_clip_slot().has_stop_button = not self.selected_clip_slot().has_stop_button
-                                        else:
-                                            if self.option_is_pressed():
-                                                self.selected_clip_slot().stop()
-                                            else:
-                                                self.selected_clip_slot().fire()
-                                else:
-                                    self._Transport__zoom_button_down = not self._Transport__zoom_button_down
-                                    self._Transport__update_zoom_button_led()
-                        else:
-                            if switch_id == SID_JOG_SCRUB:
-                                if value == BUTTON_PRESSED:
-                                    if self.session_is_visible():
-                                        if self.option_is_pressed():
-                                            self.song().stop_all_clips()
-                                        else:
-                                            self.song().view.selected_scene.fire_as_selected()
-                                    else:
-                                        self._Transport__scrub_button_down = not self._Transport__scrub_button_down
-                                        self._Transport__update_scrub_button_led()
+                        self.song().view.selected_scene.fire_as_selected()
+                else:
+                    self.__scrub_button_down = not self.__scrub_button_down
+                    self.__update_scrub_button_led()
 
     def __on_cursor_up_pressed(self):
         nav = Live.Application.Application.View.NavDirection
-        if self._Transport__zoom_button_down:
-            self.application().view.zoom_view(nav.up, "", self.alt_is_pressed())
+        if self.__zoom_button_down:
+            self.application().view.zoom_view(nav.up, '', self.alt_is_pressed())
         else:
-            self.application().view.scroll_view(nav.up, "", self.alt_is_pressed())
+            self.application().view.scroll_view(nav.up, '', self.alt_is_pressed())
 
     def __on_cursor_down_pressed(self):
         nav = Live.Application.Application.View.NavDirection
-        if self._Transport__zoom_button_down:
-            self.application().view.zoom_view(nav.down, "", self.alt_is_pressed())
+        if self.__zoom_button_down:
+            self.application().view.zoom_view(nav.down, '', self.alt_is_pressed())
         else:
-            self.application().view.scroll_view(nav.down, "", self.alt_is_pressed())
+            self.application().view.scroll_view(nav.down, '', self.alt_is_pressed())
 
     def __on_cursor_left_pressed(self):
         nav = Live.Application.Application.View.NavDirection
-        if self._Transport__zoom_button_down:
-            self.application().view.zoom_view(nav.left, "", self.alt_is_pressed())
+        if self.__zoom_button_down:
+            self.application().view.zoom_view(nav.left, '', self.alt_is_pressed())
         else:
-            self.application().view.scroll_view(nav.left, "", self.alt_is_pressed())
+            self.application().view.scroll_view(nav.left, '', self.alt_is_pressed())
 
     def __on_cursor_right_pressed(self):
         nav = Live.Application.Application.View.NavDirection
-        if self._Transport__zoom_button_down:
-            self.application().view.zoom_view(nav.right, "", self.alt_is_pressed())
+        if self.__zoom_button_down:
+            self.application().view.zoom_view(nav.right, '', self.alt_is_pressed())
         else:
-            self.application().view.scroll_view(nav.right, "", self.alt_is_pressed())
+            self.application().view.scroll_view(nav.right, '', self.alt_is_pressed())
 
     def __toggle_record(self):
         self.song().record_mode = not self.song().record_mode
@@ -383,9 +363,9 @@ class Transport(MackieControlComponent):
         self.song().current_song_time = self.song().last_event_time
 
     def __on_session_is_visible_changed(self):
-        self._Transport__last_focussed_clip_play_state = CLIP_STATE_INVALID
-        self._Transport__update_zoom_button_led()
-        self._Transport__update_scrub_button_led()
+        self.__last_focussed_clip_play_state = CLIP_STATE_INVALID
+        self.__update_zoom_button_led()
+        self.__update_scrub_button_led()
 
     def __update_zoom_led_in_session(self):
         if self.session_is_visible():
@@ -399,40 +379,38 @@ class Transport(MackieControlComponent):
                     state = CLIP_STOPPED
             else:
                 state = CLIP_STOPPED
-            if state != self._Transport__last_focussed_clip_play_state:
-                self._Transport__last_focussed_clip_play_state = state
+            if state != self.__last_focussed_clip_play_state:
+                self.__last_focussed_clip_play_state = state
                 if state == CLIP_PLAYING:
                     self.send_midi((NOTE_ON_STATUS, SID_JOG_ZOOM, BUTTON_STATE_ON))
+                elif state == CLIP_TRIGGERED:
+                    self.send_midi((NOTE_ON_STATUS, SID_JOG_ZOOM, BUTTON_STATE_BLINKING))
                 else:
-                    if state == CLIP_TRIGGERED:
-                        self.send_midi((NOTE_ON_STATUS, SID_JOG_ZOOM, BUTTON_STATE_BLINKING))
-                    else:
-                        self.send_midi((NOTE_ON_STATUS, SID_JOG_ZOOM, BUTTON_STATE_OFF))
+                    self.send_midi((NOTE_ON_STATUS, SID_JOG_ZOOM, BUTTON_STATE_OFF))
 
     def __update_forward_rewind_leds(self):
-        if self._Transport__forward_button_down:
+        if self.__forward_button_down:
             self.send_midi((NOTE_ON_STATUS, SID_TRANSPORT_FAST_FORWARD, BUTTON_STATE_ON))
-            self._Transport__transport_repeat_delay = 0
+            self.__transport_repeat_delay = 0
         else:
             self.send_midi((NOTE_ON_STATUS, SID_TRANSPORT_FAST_FORWARD, BUTTON_STATE_OFF))
-        if self._Transport____rewind_button_down:
+        if self.____rewind_button_down:
             self.send_midi((NOTE_ON_STATUS, SID_TRANSPORT_REWIND, BUTTON_STATE_ON))
-            self._Transport__transport_repeat_delay = 0
+            self.__transport_repeat_delay = 0
         else:
             self.send_midi((NOTE_ON_STATUS, SID_TRANSPORT_REWIND, BUTTON_STATE_OFF))
 
     def __update_zoom_button_led(self):
         if self.session_is_visible():
-            self._Transport__update_zoom_led_in_session()
+            self.__update_zoom_led_in_session()
+        elif self.__zoom_button_down:
+            self.send_midi((NOTE_ON_STATUS, SID_JOG_ZOOM, BUTTON_STATE_ON))
         else:
-            if self._Transport__zoom_button_down:
-                self.send_midi((NOTE_ON_STATUS, SID_JOG_ZOOM, BUTTON_STATE_ON))
-            else:
-                self.send_midi((NOTE_ON_STATUS, SID_JOG_ZOOM, BUTTON_STATE_OFF))
+            self.send_midi((NOTE_ON_STATUS, SID_JOG_ZOOM, BUTTON_STATE_OFF))
 
     def __update_scrub_button_led(self):
-        if self._Transport__scrub_button_down:
-            self.session_is_visible() or self.send_midi((NOTE_ON_STATUS, SID_JOG_SCRUB, BUTTON_STATE_ON))
+        if self.__scrub_button_down and (not self.session_is_visible()):
+            self.send_midi((NOTE_ON_STATUS, SID_JOG_SCRUB, BUTTON_STATE_ON))
         else:
             self.send_midi((NOTE_ON_STATUS, SID_JOG_SCRUB, BUTTON_STATE_OFF))
 

--- a/MackieControl/__init__.py
+++ b/MackieControl/__init__.py
@@ -1,11 +1,10 @@
-# uncompyle6 version 3.9.1
-# Python bytecode version base 3.7.0 (3394)
-# Decompiled from: Python 3.12.2 (main, Feb  6 2024, 20:19:44) [Clang 15.0.0 (clang-1500.1.0.2.5)]
-# Embedded file name: output/Live/mac_universal_64_static/Release/python-bundle/MIDI Remote Scripts/MackieControl/__init__.py
-# Compiled at: 2024-03-09 01:30:22
-# Size of source mod 2**32: 1277 bytes
-from __future__ import absolute_import, print_function, unicode_literals
+# Decompiled with PyLingual (https://pylingual.io)
+# Internal filename: ..\..\..\output\Live\win_64_static\Release\python-bundle\MIDI Remote Scripts\MackieControl\__init__.py
+# Bytecode version: 3.11a7e (3495)
+# Source timestamp: 2024-09-26 15:27:47 UTC (1727364467)
+
 from .MackieControl import MackieControl
+
 
 def create_instance(c_instance):
     return MackieControl(c_instance)
@@ -13,17 +12,11 @@ def create_instance(c_instance):
 
 from _Framework.Capabilities import *
 
+
 def get_capabilities():
-    return {CONTROLLER_ID_KEY: (controller_id(vendor_id=2675,
-                          product_ids=[6],
-                          model_name="MCU Pro USB v3.1")), 
-     
-     PORTS_KEY: [
-                 inport(props=[SCRIPT, REMOTE]),
-                 inport(props=[]),
-                 inport(props=[]),
-                 inport(props=[]),
-                 outport(props=[SCRIPT, REMOTE]),
-                 outport(props=[]),
-                 outport(props=[]),
-                 outport(props=[])]}
+    return {CONTROLLER_ID_KEY: controller_id(vendor_id=2675, product_ids=[6],
+                                             model_name='MCU Pro USB v3.1'),
+            PORTS_KEY: [inport(props=[SCRIPT, REMOTE]), inport(props=[]),
+                        inport(props=[]), inport(props=[]),
+                        outport(props=[SCRIPT, REMOTE]), outport(props=[]),
+                        outport(props=[]), outport(props=[])]}

--- a/MackieControl/consts.py
+++ b/MackieControl/consts.py
@@ -1,11 +1,8 @@
-# uncompyle6 version 3.9.1
-# Python bytecode version base 3.7.0 (3394)
-# Decompiled from: Python 3.12.2 (main, Feb  6 2024, 20:19:44) [Clang 15.0.0 (clang-1500.1.0.2.5)]
-# Embedded file name: output/Live/mac_universal_64_static/Release/python-bundle/MIDI Remote Scripts/MackieControl/consts.py
-# Compiled at: 2024-03-09 01:30:22
-# Size of source mod 2**32: 7807 bytes
-from __future__ import absolute_import, print_function, unicode_literals
-from builtins import range
+# Decompiled with PyLingual (https://pylingual.io)
+# Internal filename: ..\..\..\output\Live\win_64_static\Release\python-bundle\MIDI Remote Scripts\MackieControl\consts.py
+# Bytecode version: 3.11a7e (3495)
+# Source timestamp: 2024-09-26 15:27:47 UTC (1727364467)
+
 NOTE_OFF_STATUS = 128
 NOTE_ON_STATUS = 144
 CC_STATUS = 176
@@ -42,61 +39,19 @@ CSM_IO_LAST_MODE = CSM_IO_MODE_OUTPUT_SUB
 PCM_DEVICES = 0
 PCM_PARAMETERS = 1
 PCM_NUMMODES = 2
-CLIP_STATE_INVALID = -1
+CLIP_STATE_INVALID = (-1)
 CLIP_STOPPED = 0
 CLIP_TRIGGERED = 1
 CLIP_PLAYING = 2
-g7_seg_led_conv_table = {
- ' ': 0, 
- 'A': 1, 
- 'B': 2, 
- 'C': 3, 
- 'D': 4, 
- 'E': 5, 
- 'F': 6, 
- 'G': 7, 
- 'H': 8, 
- 'I': 9, 
- 'J': 10, 
- 'K': 11, 
- 'L': 12, 
- 'M': 13, 
- 'N': 14, 
- 'O': 15, 
- 'P': 16, 
- 'Q': 17, 
- 'R': 18, 
- 'S': 19, 
- 'T': 20, 
- 'U': 21, 
- 'V': 22, 
- 'W': 23, 
- 'X': 24, 
- 'Y': 25, 
- 'Z': 26, 
- '\\': 34, 
- '#': 35, 
- '$': 36, 
- '%': 37, 
- '&': 38, 
- "'": 39, 
- '(': 40, 
- ')': 41, 
- '*': 42, 
- '+': 43, 
- ',': 44, 
- '0': 48, 
- '1': 49, 
- '2': 50, 
- '3': 51, 
- '4': 52, 
- '5': 53, 
- '6': 54, 
- '7': 55, 
- '8': 56, 
- '9': 57, 
- ';': 59, 
- '<': 60}
+g7_seg_led_conv_table = {' ': 0, 'A': 1, 'B': 2, 'C': 3, 'D': 4, 'E': 5, 'F': 6,
+                         'G': 7, 'H': 8, 'I': 9, 'J': 10, 'K': 11, 'L': 12,
+                         'M': 13, 'N': 14, 'O': 15, 'P': 16, 'Q': 17, 'R': 18,
+                         'S': 19, 'T': 20, 'U': 21, 'V': 22, 'W': 23, 'X': 24,
+                         'Y': 25, 'Z': 26, '\\': 34, '#': 35, '$': 36, '%': 37,
+                         '&': 38, "'": 39, '(': 40, ')': 41, '*': 42, '+': 43,
+                         ',': 44, '0': 48, '1': 49, '2': 50, '3': 51, '4': 52,
+                         '5': 53, '6': 54, '7': 55, '8': 56, '9': 57, ';': 59,
+                         '<': 60}
 SID_FIRST = 0
 SID_RECORD_ARM_BASE = 0
 SID_RECORD_ARM_CH1 = 0
@@ -143,24 +98,28 @@ SID_VPOD_PUSH_CH5 = 36
 SID_VPOD_PUSH_CH6 = 37
 SID_VPOD_PUSH_CH7 = 38
 SID_VPOD_PUSH_CH8 = 39
-channel_strip_switch_ids = list(range(SID_RECORD_ARM_BASE, SID_VPOD_PUSH_CH8 + 1))
+channel_strip_switch_ids = list(
+    range(SID_RECORD_ARM_BASE, SID_VPOD_PUSH_CH8 + 1))
 SID_ASSIGNMENT_IO = 40
 SID_ASSIGNMENT_SENDS = 41
 SID_ASSIGNMENT_PAN = 42
 SID_ASSIGNMENT_PLUG_INS = 43
 SID_ASSIGNMENT_EQ = 44
 SID_ASSIGNMENT_DYNAMIC = 45
-channel_strip_assignment_switch_ids = list(range(SID_ASSIGNMENT_IO, SID_ASSIGNMENT_DYNAMIC + 1))
+channel_strip_assignment_switch_ids = list(
+    range(SID_ASSIGNMENT_IO, SID_ASSIGNMENT_DYNAMIC + 1))
 SID_FADERBANK_PREV_BANK = 46
 SID_FADERBANK_NEXT_BANK = 47
 SID_FADERBANK_PREV_CH = 48
 SID_FADERBANK_NEXT_CH = 49
 SID_FADERBANK_FLIP = 50
 SID_FADERBANK_EDIT = 51
-channel_strip_control_switch_ids = list(range(SID_ASSIGNMENT_IO, SID_FADERBANK_EDIT + 1))
+channel_strip_control_switch_ids = list(
+    range(SID_ASSIGNMENT_IO, SID_FADERBANK_EDIT + 1))
 SID_DISPLAY_NAME_VALUE = 52
 SID_DISPLAY_SMPTE_BEATS = 53
-display_switch_ids = list(range(SID_DISPLAY_NAME_VALUE, SID_DISPLAY_SMPTE_BEATS + 1))
+display_switch_ids = list(
+    range(SID_DISPLAY_NAME_VALUE, SID_DISPLAY_SMPTE_BEATS + 1))
 SID_SOFTWARE_F1 = 54
 SID_SOFTWARE_F2 = 55
 SID_SOFTWARE_F3 = 56
@@ -177,7 +136,8 @@ SID_SOFTWARE_F13 = 66
 SID_SOFTWARE_F14 = 67
 SID_SOFTWARE_F15 = 68
 SID_SOFTWARE_F16 = 69
-function_key_control_switch_ids = list(range(SID_SOFTWARE_F1, SID_SOFTWARE_F16 + 1))
+function_key_control_switch_ids = list(
+    range(SID_SOFTWARE_F1, SID_SOFTWARE_F16 + 1))
 SID_MOD_SHIFT = 70
 SID_MOD_OPTION = 71
 SID_MOD_CTRL = 72
@@ -193,26 +153,17 @@ SID_FUNC_REDO = 79
 SID_FUNC_MARKER = 82
 SID_FUNC_MIXER = 83
 software_controls_switch_ids = (
- SID_MOD_SHIFT,
- SID_MOD_OPTION,
- SID_MOD_CTRL,
- SID_MOD_ALT,
- SID_AUTOMATION_ON,
- SID_AUTOMATION_RECORD,
- SID_AUTOMATION_SNAPSHOT,
- SID_AUTOMATION_TOUCH,
- SID_FUNC_UNDO,
- SID_FUNC_CANCEL,
- SID_FUNC_ENTER,
- SID_FUNC_REDO,
- SID_FUNC_MARKER,
- SID_FUNC_MIXER)
+    SID_MOD_SHIFT, SID_MOD_OPTION, SID_MOD_CTRL, SID_MOD_ALT, SID_AUTOMATION_ON,
+    SID_AUTOMATION_RECORD, SID_AUTOMATION_SNAPSHOT, SID_AUTOMATION_TOUCH,
+    SID_FUNC_UNDO, SID_FUNC_CANCEL, SID_FUNC_ENTER, SID_FUNC_REDO,
+    SID_FUNC_MARKER, SID_FUNC_MIXER)
 SID_TRANSPORT_REWIND = 91
 SID_TRANSPORT_FAST_FORWARD = 92
 SID_TRANSPORT_STOP = 93
 SID_TRANSPORT_PLAY = 94
 SID_TRANSPORT_RECORD = 95
-transport_control_switch_ids = list(range(SID_TRANSPORT_REWIND, SID_TRANSPORT_RECORD + 1))
+transport_control_switch_ids = list(
+    range(SID_TRANSPORT_REWIND, SID_TRANSPORT_RECORD + 1))
 SID_MARKER_FROM_PREV = 84
 SID_MARKER_FROM_NEXT = 85
 SID_MARKER_LOOP = 86
@@ -221,13 +172,8 @@ SID_MARKER_PO = 88
 SID_MARKER_HOME = 89
 SID_MARKER_END = 90
 marker_control_switch_ids = (
- SID_MARKER_FROM_PREV,
- SID_MARKER_FROM_NEXT,
- SID_MARKER_LOOP,
- SID_MARKER_PI,
- SID_MARKER_PO,
- SID_MARKER_HOME,
- SID_MARKER_END)
+    SID_MARKER_FROM_PREV, SID_MARKER_FROM_NEXT, SID_MARKER_LOOP, SID_MARKER_PI,
+    SID_MARKER_PO, SID_MARKER_HOME, SID_MARKER_END)
 SID_JOG_CURSOR_UP = 96
 SID_JOG_CURSOR_DOWN = 97
 SID_JOG_CURSOR_LEFT = 98
@@ -247,5 +193,6 @@ SID_FADER_TOUCH_SENSE_CH6 = 109
 SID_FADER_TOUCH_SENSE_CH7 = 110
 SID_FADER_TOUCH_SENSE_CH8 = 111
 SID_FADER_TOUCH_SENSE_MASTER = 112
-fader_touch_switch_ids = list(range(SID_FADER_TOUCH_SENSE_CH1, SID_FADER_TOUCH_SENSE_MASTER + 1))
+fader_touch_switch_ids = list(
+    range(SID_FADER_TOUCH_SENSE_CH1, SID_FADER_TOUCH_SENSE_MASTER + 1))
 SID_LAST = 112


### PR DESCRIPTION
All files decompiled using PyLingual; some i had to manually fix and patch but now their pyc files are identical to the original pyc files by Ableton, Apart from this 
```
    try:
        from ableton.v3.control_surface.capabilities import AUTO_LOAD_KEY
    except ImportError:
        from ableton.v2.control_surface.capabilities import AUTO_LOAD_KEY
```
I dont have the device yet so i cant check if this is needed and i dont know if 

``from ableton.v3.live import simple_track_name``

exists or works in the current version but here you go anyway
    
   